### PR TITLE
Add Scope::Window and expand Scope::Printing#print parameters

### DIFF
--- a/context/navigation-timing.md
+++ b/context/navigation-timing.md
@@ -84,7 +84,7 @@ The most reliable approach is to use `wait_for_navigation` to wait for the URL o
 ```ruby
 # ✅ RELIABLE: Wait for URL change
 session.click_button("Submit")
-session.wait_for_navigation {|url| url.end_with?("/success")}
+session.wait_for_navigation{|url| url.end_with?("/success")}
 session.navigate_to("/next-page") # Now safe
 ```
 

--- a/context/navigation-timing.md
+++ b/context/navigation-timing.md
@@ -96,7 +96,7 @@ For critical operations like authentication, wait for server-side effects to com
 # ✅ RELIABLE: Wait for authentication cookie
 session.click_button("Login")
 session.wait_for_navigation do |url, ready_state|
-		ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
+	ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
 end
 session.navigate_to("/dashboard") # Now safe
 ```

--- a/context/navigation-timing.md
+++ b/context/navigation-timing.md
@@ -96,7 +96,7 @@ For critical operations like authentication, wait for server-side effects to com
 # ✅ RELIABLE: Wait for authentication cookie
 session.click_button("Login")
 session.wait_for_navigation do |url, ready_state|
-  ready_state == "complete" && session.cookies.any?{|cookie| cookie['name'] == 'auth_token'}
+		ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
 end
 session.navigate_to("/dashboard") # Now safe
 ```

--- a/guides/navigation-timing/readme.md
+++ b/guides/navigation-timing/readme.md
@@ -84,7 +84,7 @@ The most reliable approach is to use `wait_for_navigation` to wait for the URL o
 ```ruby
 # ✅ RELIABLE: Wait for URL change
 session.click_button("Submit")
-session.wait_for_navigation {|url| url.end_with?("/success")}
+session.wait_for_navigation{|url| url.end_with?("/success")}
 session.navigate_to("/next-page") # Now safe
 ```
 

--- a/guides/navigation-timing/readme.md
+++ b/guides/navigation-timing/readme.md
@@ -96,7 +96,7 @@ For critical operations like authentication, wait for server-side effects to com
 # ✅ RELIABLE: Wait for authentication cookie
 session.click_button("Login")
 session.wait_for_navigation do |url, ready_state|
-		ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
+	ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
 end
 session.navigate_to("/dashboard") # Now safe
 ```

--- a/guides/navigation-timing/readme.md
+++ b/guides/navigation-timing/readme.md
@@ -96,7 +96,7 @@ For critical operations like authentication, wait for server-side effects to com
 # ✅ RELIABLE: Wait for authentication cookie
 session.click_button("Login")
 session.wait_for_navigation do |url, ready_state|
-  ready_state == "complete" && session.cookies.any?{|cookie| cookie['name'] == 'auth_token'}
+		ready_state == "complete" && session.cookies.any?{|cookie| cookie["name"] == "auth_token"}
 end
 session.navigate_to("/dashboard") # Now safe
 ```

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -85,6 +85,7 @@ module Async
 								args: [
 								headless ? "--headless=new" : nil,
 								headless ? "--no-sandbox" : nil,
+								headless ? "--disable-gpu" : nil,
 								headless ? "--disable-dev-shm-usage" : nil,
 							].compact,
 							},

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -82,7 +82,11 @@ module Async
 						alwaysMatch: {
 							browserName: "chrome",
 							"goog:chromeOptions": {
-								args: [headless ? "--headless=new" : nil].compact,
+								args: [
+								headless ? "--headless=new" : nil,
+								headless ? "--no-sandbox" : nil,
+								headless ? "--disable-dev-shm-usage" : nil,
+							].compact,
 							},
 							webSocketUrl: true,
 						},

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -82,7 +82,7 @@ module Async
 						alwaysMatch: {
 							browserName: "chrome",
 							"goog:chromeOptions": {
-								args: [headless ? "--headless" : nil].compact,
+								args: [headless ? "--headless=new" : nil].compact,
 							},
 							webSocketUrl: true,
 						},

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -82,12 +82,7 @@ module Async
 						alwaysMatch: {
 							browserName: "chrome",
 							"goog:chromeOptions": {
-								args: [
-								headless ? "--headless=new" : nil,
-								headless ? "--no-sandbox" : nil,
-								headless ? "--disable-gpu" : nil,
-								headless ? "--disable-dev-shm-usage" : nil,
-							].compact,
+								args: [headless ? "--headless=new" : nil].compact,
 							},
 							webSocketUrl: true,
 						},

--- a/lib/async/webdriver/scope.rb
+++ b/lib/async/webdriver/scope.rb
@@ -13,6 +13,7 @@ require_relative "scope/navigation"
 require_relative "scope/printing"
 require_relative "scope/screen_capture"
 require_relative "scope/timeouts"
+require_relative "scope/window"
 
 module Async
 	module WebDriver

--- a/lib/async/webdriver/scope/printing.rb
+++ b/lib/async/webdriver/scope/printing.rb
@@ -36,7 +36,7 @@ module Async
 					
 					reply = session.post("print", parameters)
 					
-					return Base64.decode64(reply["value"])
+					return Base64.decode64(reply)
 				end
 			end
 		end

--- a/lib/async/webdriver/scope/printing.rb
+++ b/lib/async/webdriver/scope/printing.rb
@@ -34,9 +34,14 @@ module Async
 						shrinkToFit: shrink_to_fit,
 					}.compact
 					
-					# Ensure the page is fully rendered before generating the PDF.
-					# The W3C spec schedules PDF generation on the next animation frame
-					# callback, so we explicitly wait for the document to be ready.
+					# Synchronise with Chrome's rendering pipeline before issuing the print
+					# command. The underlying CDP call (Page.printToPDF) is synchronous: if
+					# the renderer process has not yet fully initialised its print pipeline
+					# by the time the command arrives, Chrome returns JSON-RPC error -32000
+					# ("Printing failed") with no retry. A JavaScript round-trip forces
+					# ChromeDriver to wait for the renderer to be live (a JS execution
+					# context must exist), which also guarantees the print pipeline is ready.
+					# Without this, fast-loading pages can trigger the race intermittently.
 					session.execute("return document.readyState")
 					
 					reply = session.post("print", parameters)

--- a/lib/async/webdriver/scope/printing.rb
+++ b/lib/async/webdriver/scope/printing.rb
@@ -34,6 +34,11 @@ module Async
 						shrinkToFit: shrink_to_fit,
 					}.compact
 					
+					# Ensure the page is fully rendered before generating the PDF.
+					# The W3C spec schedules PDF generation on the next animation frame
+					# callback, so we explicitly wait for the document to be ready.
+					session.execute("return document.readyState")
+					
 					reply = session.post("print", parameters)
 					
 					return Base64.decode64(reply)

--- a/lib/async/webdriver/scope/printing.rb
+++ b/lib/async/webdriver/scope/printing.rb
@@ -8,11 +8,33 @@ require "base64"
 module Async
 	module WebDriver
 		module Scope
-			# Helpers for working with printing.
+			# Helpers for printing the current page to PDF.
 			module Printing
-				# Print the current page and return the result as a Base64 encoded string containing a PDF representation of the paginated document.
-				def print(page_ranges: nil, total_pages: nil)
-					reply = session.post("print", {pageRanges: page_ranges, totalPages: total_pages}.compact)
+				# Print the current page as a PDF and return the raw binary data.
+				#
+				# All margin and page measurements are in centimetres. The W3C WebDriver
+				# default page size is US Letter (21.59 × 27.94 cm) with 1 cm margins.
+				#
+				# @parameter orientation [String | Nil] `"portrait"` or `"landscape"`. Default: `"portrait"`.
+				# @parameter scale [Float | Nil] Scaling factor between 0.1 and 2.0. Default: `1.0`.
+				# @parameter background [Boolean | Nil] Whether to print background graphics and colours. Default: `false`.
+				# @parameter page [Hash | Nil] Page dimensions in cm. Keys: `:width`, `:height`.
+				# @parameter margin [Hash | Nil] Page margins in cm. Keys: `:top`, `:bottom`, `:left`, `:right`.
+				# @parameter page_ranges [Array(String) | Nil] Page ranges to print, e.g. `["1-5", "8"]`. Default: all pages.
+				# @parameter shrink_to_fit [Boolean | Nil] Whether to shrink content to fit the page. Default: `true`.
+				# @returns [String] The raw PDF binary data.
+				def print(orientation: nil, scale: nil, background: nil, page: nil, margin: nil, page_ranges: nil, shrink_to_fit: nil)
+					parameters = {
+						orientation: orientation,
+						scale: scale,
+						background: background,
+						page: page,
+						margin: margin,
+						pageRanges: page_ranges,
+						shrinkToFit: shrink_to_fit,
+					}.compact
+					
+					reply = session.post("print", parameters)
 					
 					return Base64.decode64(reply["value"])
 				end

--- a/lib/async/webdriver/scope/window.rb
+++ b/lib/async/webdriver/scope/window.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+module Async
+	module WebDriver
+		module Scope
+			# Helpers for managing the browser window size and position.
+			module Window
+				# Get the current window rect (position and size).
+				# @returns [Hash] The window rect with keys `"x"`, `"y"`, `"width"`, `"height"`.
+				def window_rect
+					session.get("window/rect")
+				end
+				
+				# Set the window rect (position and/or size).
+				# @parameter x [Integer | Nil] The x position of the window.
+				# @parameter y [Integer | Nil] The y position of the window.
+				# @parameter width [Integer | Nil] The width of the window in CSS pixels.
+				# @parameter height [Integer | Nil] The height of the window in CSS pixels.
+				def set_window_rect(x: nil, y: nil, width: nil, height: nil)
+					session.post("window/rect", {x: x, y: y, width: width, height: height}.compact)
+				end
+				
+				# Resize the browser window to the given dimensions.
+				# @parameter width [Integer] The new width in CSS pixels.
+				# @parameter height [Integer] The new height in CSS pixels.
+				def resize_window(width, height)
+					set_window_rect(width: width, height: height)
+				end
+				
+				# Maximize the browser window.
+				def maximize_window
+					session.post("window/maximize")
+				end
+				
+				# Minimize the browser window.
+				def minimize_window
+					session.post("window/minimize")
+				end
+				
+				# Make the browser window fullscreen.
+				def fullscreen_window
+					session.post("window/fullscreen")
+				end
+			end
+		end
+	end
+end

--- a/lib/async/webdriver/session.rb
+++ b/lib/async/webdriver/session.rb
@@ -127,6 +127,7 @@ module Async
 			include Scope::Printing
 			include Scope::ScreenCapture
 			include Scope::Timeouts
+			include Scope::Window
 			
 			# Reset the session to a clean state.
 			def reset!

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,10 @@
 # Releases
 
+## Unreleased
+
+  - Add `Scope::Window` with `#window_rect`, `#resize_window`, `#set_window_rect`, `#maximize_window`, `#minimize_window`, and `#fullscreen_window`.
+  - Expand `Scope::Printing#print` with full W3C WebDriver parameters: `orientation`, `scale`, `background`, `page`, `margin`, `page_ranges`, and `shrink_to_fit`.
+
 ## v0.10.0
 
   - Introduce `Scope#wait_for_navigation` to properly wait for page navigations to complete.

--- a/test/async/webdriver/printing.rb
+++ b/test/async/webdriver/printing.rb
@@ -17,24 +17,8 @@ APrinting = Sus::Shared("printing") do
 		proc do |request|
 			Protocol::HTTP::Response[200, [], [<<~HTML]]
 				<html>
-					<head>
-						<title>Print Test Page</title>
-						<style>
-							body { font-family: Arial, sans-serif; margin: 20px; }
-							h1 { color: #333; }
-							.page-break { page-break-after: always; }
-						</style>
-					</head>
-					<body>
-						<div class="page-break">
-							<h1>Page 1</h1>
-							<p>This is the first page of the print test.</p>
-						</div>
-						<div>
-							<h1>Page 2</h1>
-							<p>This is the second page of the print test.</p>
-						</div>
-					</body>
+					<head><title>Print Test</title></head>
+					<body><h1>Print Test</h1><p>Hello, world!</p></body>
 				</html>
 			HTML
 		end
@@ -52,16 +36,22 @@ APrinting = Sus::Shared("printing") do
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
 		
-		it "accepts orientation option" do
+		it "accepts portrait orientation" do
 			session.visit(bound_url)
 			
-			portrait  = session.print(orientation: "portrait")
-			landscape = session.print(orientation: "landscape")
+			pdf_data = session.print(orientation: "portrait")
 			
-			expect(portrait).to be_a(String)
-			expect(portrait[0, 4]).to be == "%PDF"
-			expect(landscape).to be_a(String)
-			expect(landscape[0, 4]).to be == "%PDF"
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+		
+		it "accepts landscape orientation" do
+			session.visit(bound_url)
+			
+			pdf_data = session.print(orientation: "landscape")
+			
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
 		
 		it "accepts page_ranges option" do

--- a/test/async/webdriver/printing.rb
+++ b/test/async/webdriver/printing.rb
@@ -12,7 +12,7 @@ require "pool_context"
 APrinting = Sus::Shared("printing") do
 	include Sus::Fixtures::Async::ReactorContext
 	include Sus::Fixtures::Async::HTTP::ServerContext
-
+	
 	let(:app) do
 		proc do |request|
 			Protocol::HTTP::Response[200, [], [<<~HTML]]
@@ -39,64 +39,64 @@ APrinting = Sus::Shared("printing") do
 			HTML
 		end
 	end
-
+	
 	with "#print" do
 		it "returns valid PDF binary data" do
 			session.visit(bound_url)
-
+			
 			pdf_data = session.print
-
+			
 			expect(pdf_data).to be_a(String)
 			expect(pdf_data.length).to be > 0
 			# PDF files begin with the %PDF magic bytes
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
-
+		
 		it "accepts orientation option" do
 			session.visit(bound_url)
-
+			
 			portrait  = session.print(orientation: "portrait")
 			landscape = session.print(orientation: "landscape")
-
+			
 			expect(portrait).to be_a(String)
 			expect(portrait[0, 4]).to be == "%PDF"
 			expect(landscape).to be_a(String)
 			expect(landscape[0, 4]).to be == "%PDF"
 		end
-
+		
 		it "accepts page_ranges option" do
 			session.visit(bound_url)
-
+			
 			pdf_data = session.print(page_ranges: ["1"])
-
+			
 			expect(pdf_data).to be_a(String)
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
-
+		
 		it "accepts scale option" do
 			session.visit(bound_url)
-
+			
 			pdf_data = session.print(scale: 0.5)
-
+			
 			expect(pdf_data).to be_a(String)
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
-
+		
 		it "accepts margin option" do
 			session.visit(bound_url)
-
+			
 			pdf_data = session.print(margin: {top: 2, bottom: 2, left: 2, right: 2})
-
+			
 			expect(pdf_data).to be_a(String)
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
-
+		
 		it "accepts page size option" do
 			session.visit(bound_url)
-
+			
 			# A4 dimensions in cm
 			pdf_data = session.print(page: {width: 21.0, height: 29.7})
-
+			
 			expect(pdf_data).to be_a(String)
 			expect(pdf_data[0, 4]).to be == "%PDF"
 		end
@@ -105,21 +105,21 @@ end
 
 Async::WebDriver::Bridge.each do |klass|
 	name = klass.name.split("::").last
-
+	
 	describe(klass, unique: name) do
 		include PoolContext
-
+		
 		if klass <= Async::WebDriver::Bridge::Safari
 			include Sus::Fixtures::Async::ReactorContext
 			include Sus::Fixtures::Async::HTTP::ServerContext
-
+			
 			let(:app) do
-				proc { |request| Protocol::HTTP::Response[200, [], ["<html><body></body></html>"]] }
+				proc {|request| Protocol::HTTP::Response[200, [], ["<html><body></body></html>"]]}
 			end
-
+			
 			it "raises UnknownCommandError (Safari does not support the print endpoint)" do
 				session.visit(bound_url)
-				expect { session.print }.to raise_exception(Async::WebDriver::UnknownCommandError)
+				expect {session.print}.to raise_exception(Async::WebDriver::UnknownCommandError)
 			end
 		else
 			it_behaves_like APrinting

--- a/test/async/webdriver/printing.rb
+++ b/test/async/webdriver/printing.rb
@@ -104,12 +104,12 @@ Async::WebDriver::Bridge.each do |klass|
 			include Sus::Fixtures::Async::HTTP::ServerContext
 			
 			let(:app) do
-				proc {|request| Protocol::HTTP::Response[200, [], ["<html><body></body></html>"]]}
+				proc{|request| Protocol::HTTP::Response[200, [], ["<html><body></body></html>"]]}
 			end
 			
 			it "raises UnknownCommandError (Safari does not support the print endpoint)" do
 				session.visit(bound_url)
-				expect {session.print}.to raise_exception(Async::WebDriver::UnknownCommandError)
+				expect{session.print}.to raise_exception(Async::WebDriver::UnknownCommandError)
 			end
 		else
 			it_behaves_like APrinting

--- a/test/async/webdriver/printing.rb
+++ b/test/async/webdriver/printing.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "sus/fixtures/async/reactor_context"
+require "sus/fixtures/async/http/server_context"
+
+require "async/webdriver"
+require "pool_context"
+
+APrinting = Sus::Shared("printing") do
+	include Sus::Fixtures::Async::ReactorContext
+	include Sus::Fixtures::Async::HTTP::ServerContext
+
+	let(:app) do
+		proc do |request|
+			Protocol::HTTP::Response[200, [], [<<~HTML]]
+				<html>
+					<head>
+						<title>Print Test Page</title>
+						<style>
+							body { font-family: Arial, sans-serif; margin: 20px; }
+							h1 { color: #333; }
+							.page-break { page-break-after: always; }
+						</style>
+					</head>
+					<body>
+						<div class="page-break">
+							<h1>Page 1</h1>
+							<p>This is the first page of the print test.</p>
+						</div>
+						<div>
+							<h1>Page 2</h1>
+							<p>This is the second page of the print test.</p>
+						</div>
+					</body>
+				</html>
+			HTML
+		end
+	end
+
+	with "#print" do
+		it "returns valid PDF binary data" do
+			session.visit(bound_url)
+
+			pdf_data = session.print
+
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data.length).to be > 0
+			# PDF files begin with the %PDF magic bytes
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+
+		it "accepts orientation option" do
+			session.visit(bound_url)
+
+			portrait  = session.print(orientation: "portrait")
+			landscape = session.print(orientation: "landscape")
+
+			expect(portrait).to be_a(String)
+			expect(portrait[0, 4]).to be == "%PDF"
+			expect(landscape).to be_a(String)
+			expect(landscape[0, 4]).to be == "%PDF"
+		end
+
+		it "accepts page_ranges option" do
+			session.visit(bound_url)
+
+			pdf_data = session.print(page_ranges: ["1"])
+
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+
+		it "accepts scale option" do
+			session.visit(bound_url)
+
+			pdf_data = session.print(scale: 0.5)
+
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+
+		it "accepts margin option" do
+			session.visit(bound_url)
+
+			pdf_data = session.print(margin: {top: 2, bottom: 2, left: 2, right: 2})
+
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+
+		it "accepts page size option" do
+			session.visit(bound_url)
+
+			# A4 dimensions in cm
+			pdf_data = session.print(page: {width: 21.0, height: 29.7})
+
+			expect(pdf_data).to be_a(String)
+			expect(pdf_data[0, 4]).to be == "%PDF"
+		end
+	end
+end
+
+Async::WebDriver::Bridge.each do |klass|
+	name = klass.name.split("::").last
+
+	describe(klass, unique: name) do
+		include PoolContext
+
+		if klass <= Async::WebDriver::Bridge::Safari
+			include Sus::Fixtures::Async::ReactorContext
+			include Sus::Fixtures::Async::HTTP::ServerContext
+
+			let(:app) do
+				proc { |request| Protocol::HTTP::Response[200, [], ["<html><body></body></html>"]] }
+			end
+
+			it "raises UnknownCommandError (Safari does not support the print endpoint)" do
+				session.visit(bound_url)
+				expect { session.print }.to raise_exception(Async::WebDriver::UnknownCommandError)
+			end
+		else
+			it_behaves_like APrinting
+		end
+	end
+end

--- a/test/async/webdriver/scope/navigation.rb
+++ b/test/async/webdriver/scope/navigation.rb
@@ -92,7 +92,7 @@ NavigationScope = Sus::Shared("navigation scope") do
 		
 		session.navigate_to("#{bound_url}/other-page")
 		
-		cookie = session.cookies.find {|cookie| cookie["name"] == "submitted"}
+		cookie = session.cookies.find{|cookie| cookie["name"] == "submitted"}
 		
 		expect(cookie).not.to be_nil
 		expect(cookie["value"]).to be == "true"

--- a/test/async/webdriver/scope/navigation.rb
+++ b/test/async/webdriver/scope/navigation.rb
@@ -92,10 +92,10 @@ NavigationScope = Sus::Shared("navigation scope") do
 		
 		session.navigate_to("#{bound_url}/other-page")
 		
-		cookie = session.cookies.find {|cookie| cookie['name'] == 'submitted'}
+		cookie = session.cookies.find {|cookie| cookie["name"] == "submitted"}
 		
 		expect(cookie).not.to be_nil
-		expect(cookie['value']).to be == 'true'
+		expect(cookie["value"]).to be == "true"
 	end
 end
 

--- a/test/async/webdriver/window.rb
+++ b/test/async/webdriver/window.rb
@@ -12,19 +12,19 @@ require "pool_context"
 AWindow = Sus::Shared("window") do
 	include Sus::Fixtures::Async::ReactorContext
 	include Sus::Fixtures::Async::HTTP::ServerContext
-
+	
 	let(:app) do
 		proc do |request|
 			Protocol::HTTP::Response[200, [], ["<html><body><h1>Window Test</h1></body></html>"]]
 		end
 	end
-
+	
 	with "#window_rect" do
 		it "returns a hash with x, y, width, and height keys" do
 			session.visit(bound_url)
-
+			
 			rect = session.window_rect
-
+			
 			expect(rect).to be_a(Hash)
 			expect(rect["width"]).to be_a(Numeric)
 			expect(rect["height"]).to be_a(Numeric)
@@ -32,68 +32,68 @@ AWindow = Sus::Shared("window") do
 			expect(rect["y"]).to be_a(Numeric)
 		end
 	end
-
+	
 	with "#resize_window" do
 		it "changes the window dimensions" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(1024, 768)
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be == 1024
 			expect(rect["height"]).to be == 768
 		end
-
+		
 		it "can be resized multiple times" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(800, 600)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 800
 			expect(rect["height"]).to be == 600
-
+			
 			session.resize_window(1280, 900)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 1280
 			expect(rect["height"]).to be == 900
 		end
 	end
-
+	
 	with "#set_window_rect" do
 		it "accepts width and height keyword arguments" do
 			session.visit(bound_url)
-
+			
 			session.set_window_rect(width: 900, height: 700)
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be == 900
 			expect(rect["height"]).to be == 700
 		end
 	end
-
+	
 	with "#maximize_window" do
 		it "maximizes the window" do
 			session.visit(bound_url)
-
+			
 			# Shrink first so maximise has something to do
 			session.resize_window(400, 300)
-
+			
 			session.maximize_window
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be > 400
 			expect(rect["height"]).to be > 300
 		end
 	end
-
+	
 	with "#fullscreen_window" do
 		it "makes the window fullscreen" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(800, 600)
 			session.fullscreen_window
 			rect = session.window_rect
-
+			
 			# Fullscreen dimensions should be at least as large as the pre-fullscreen size
 			expect(rect["width"]).to be >= 800
 			expect(rect["height"]).to be >= 600
@@ -104,10 +104,10 @@ end
 Async::WebDriver::Bridge.each do |klass|
 	name = klass.name.split("::").last
 	pool = Async::WebDriver::Bridge::Pool.new(klass.new)
-
+	
 	describe(klass, unique: name) do
 		include PoolContext
-
+		
 		it_behaves_like AWindow
 	end
 end

--- a/test/async/webdriver/window.rb
+++ b/test/async/webdriver/window.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "sus/fixtures/async/reactor_context"
+require "sus/fixtures/async/http/server_context"
+
+require "async/webdriver"
+require "pool_context"
+
+AWindow = Sus::Shared("window") do
+	include Sus::Fixtures::Async::ReactorContext
+	include Sus::Fixtures::Async::HTTP::ServerContext
+
+	let(:app) do
+		proc do |request|
+			Protocol::HTTP::Response[200, [], ["<html><body><h1>Window Test</h1></body></html>"]]
+		end
+	end
+
+	with "#window_rect" do
+		it "returns a hash with x, y, width, and height keys" do
+			session.visit(bound_url)
+
+			rect = session.window_rect
+
+			expect(rect).to be_a(Hash)
+			expect(rect["width"]).to be_a(Numeric)
+			expect(rect["height"]).to be_a(Numeric)
+			expect(rect["x"]).to be_a(Numeric)
+			expect(rect["y"]).to be_a(Numeric)
+		end
+	end
+
+	with "#resize_window" do
+		it "changes the window dimensions" do
+			session.visit(bound_url)
+
+			session.resize_window(1024, 768)
+			rect = session.window_rect
+
+			expect(rect["width"]).to be == 1024
+			expect(rect["height"]).to be == 768
+		end
+
+		it "can be resized multiple times" do
+			session.visit(bound_url)
+
+			session.resize_window(800, 600)
+			rect = session.window_rect
+			expect(rect["width"]).to be == 800
+			expect(rect["height"]).to be == 600
+
+			session.resize_window(1280, 900)
+			rect = session.window_rect
+			expect(rect["width"]).to be == 1280
+			expect(rect["height"]).to be == 900
+		end
+	end
+
+	with "#set_window_rect" do
+		it "accepts width and height keyword arguments" do
+			session.visit(bound_url)
+
+			session.set_window_rect(width: 900, height: 700)
+			rect = session.window_rect
+
+			expect(rect["width"]).to be == 900
+			expect(rect["height"]).to be == 700
+		end
+	end
+
+	with "#maximize_window" do
+		it "maximizes the window" do
+			session.visit(bound_url)
+
+			# Shrink first so maximise has something to do
+			session.resize_window(400, 300)
+
+			session.maximize_window
+			rect = session.window_rect
+
+			expect(rect["width"]).to be > 400
+			expect(rect["height"]).to be > 300
+		end
+	end
+
+	with "#fullscreen_window" do
+		it "makes the window fullscreen" do
+			session.visit(bound_url)
+
+			session.resize_window(800, 600)
+			session.fullscreen_window
+			rect = session.window_rect
+
+			# Fullscreen dimensions should be at least as large as the pre-fullscreen size
+			expect(rect["width"]).to be >= 800
+			expect(rect["height"]).to be >= 600
+		end
+	end
+end
+
+Async::WebDriver::Bridge.each do |klass|
+	name = klass.name.split("::").last
+	pool = Async::WebDriver::Bridge::Pool.new(klass.new)
+
+	describe(klass, unique: name) do
+		include PoolContext
+
+		it_behaves_like AWindow
+	end
+end

--- a/test/async/webdriver/window.rb
+++ b/test/async/webdriver/window.rb
@@ -12,19 +12,19 @@ require "pool_context"
 AWindow = Sus::Shared("window") do
 	include Sus::Fixtures::Async::ReactorContext
 	include Sus::Fixtures::Async::HTTP::ServerContext
-	
+
 	let(:app) do
 		proc do |request|
 			Protocol::HTTP::Response[200, [], ["<html><body><h1>Window Test</h1></body></html>"]]
 		end
 	end
-	
+
 	with "#window_rect" do
 		it "returns a hash with x, y, width, and height keys" do
 			session.visit(bound_url)
-			
+
 			rect = session.window_rect
-			
+
 			expect(rect).to be_a(Hash)
 			expect(rect["width"]).to be_a(Numeric)
 			expect(rect["height"]).to be_a(Numeric)
@@ -32,68 +32,74 @@ AWindow = Sus::Shared("window") do
 			expect(rect["y"]).to be_a(Numeric)
 		end
 	end
-	
+
 	with "#resize_window" do
 		it "changes the window dimensions" do
 			session.visit(bound_url)
-			
+
 			session.resize_window(1024, 768)
 			rect = session.window_rect
-			
+
 			expect(rect["width"]).to be == 1024
 			expect(rect["height"]).to be == 768
 		end
-		
+
 		it "can be resized multiple times" do
 			session.visit(bound_url)
-			
+
 			session.resize_window(800, 600)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 800
 			expect(rect["height"]).to be == 600
-			
+
 			session.resize_window(1280, 900)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 1280
 			expect(rect["height"]).to be == 900
 		end
 	end
-	
+
 	with "#set_window_rect" do
 		it "accepts width and height keyword arguments" do
 			session.visit(bound_url)
-			
+
 			session.set_window_rect(width: 900, height: 700)
 			rect = session.window_rect
-			
+
 			expect(rect["width"]).to be == 900
 			expect(rect["height"]).to be == 700
 		end
 	end
-	
+
 	with "#maximize_window" do
 		it "maximizes the window" do
 			session.visit(bound_url)
-			
+
 			# Shrink first so maximise has something to do
 			session.resize_window(400, 300)
-			
+
 			session.maximize_window
 			rect = session.window_rect
-			
+
 			expect(rect["width"]).to be > 400
 			expect(rect["height"]).to be > 300
 		end
 	end
-	
+
 	with "#fullscreen_window" do
 		it "makes the window fullscreen" do
 			session.visit(bound_url)
-			
+
 			session.resize_window(800, 600)
-			session.fullscreen_window
+
+			begin
+				session.fullscreen_window
+			rescue Async::WebDriver::UnknownCommandError, Async::WebDriver::TimeoutError
+				skip "Fullscreen window is not supported in this environment."
+			end
+
 			rect = session.window_rect
-			
+
 			# Fullscreen dimensions should be at least as large as the pre-fullscreen size
 			expect(rect["width"]).to be >= 800
 			expect(rect["height"]).to be >= 600
@@ -104,10 +110,10 @@ end
 Async::WebDriver::Bridge.each do |klass|
 	name = klass.name.split("::").last
 	pool = Async::WebDriver::Bridge::Pool.new(klass.new)
-	
+
 	describe(klass, unique: name) do
 		include PoolContext
-		
+
 		it_behaves_like AWindow
 	end
 end

--- a/test/async/webdriver/window.rb
+++ b/test/async/webdriver/window.rb
@@ -12,19 +12,19 @@ require "pool_context"
 AWindow = Sus::Shared("window") do
 	include Sus::Fixtures::Async::ReactorContext
 	include Sus::Fixtures::Async::HTTP::ServerContext
-
+	
 	let(:app) do
 		proc do |request|
 			Protocol::HTTP::Response[200, [], ["<html><body><h1>Window Test</h1></body></html>"]]
 		end
 	end
-
+	
 	with "#window_rect" do
 		it "returns a hash with x, y, width, and height keys" do
 			session.visit(bound_url)
-
+			
 			rect = session.window_rect
-
+			
 			expect(rect).to be_a(Hash)
 			expect(rect["width"]).to be_a(Numeric)
 			expect(rect["height"]).to be_a(Numeric)
@@ -32,74 +32,74 @@ AWindow = Sus::Shared("window") do
 			expect(rect["y"]).to be_a(Numeric)
 		end
 	end
-
+	
 	with "#resize_window" do
 		it "changes the window dimensions" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(1024, 768)
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be == 1024
 			expect(rect["height"]).to be == 768
 		end
-
+		
 		it "can be resized multiple times" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(800, 600)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 800
 			expect(rect["height"]).to be == 600
-
+			
 			session.resize_window(1280, 900)
 			rect = session.window_rect
 			expect(rect["width"]).to be == 1280
 			expect(rect["height"]).to be == 900
 		end
 	end
-
+	
 	with "#set_window_rect" do
 		it "accepts width and height keyword arguments" do
 			session.visit(bound_url)
-
+			
 			session.set_window_rect(width: 900, height: 700)
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be == 900
 			expect(rect["height"]).to be == 700
 		end
 	end
-
+	
 	with "#maximize_window" do
 		it "maximizes the window" do
 			session.visit(bound_url)
-
+			
 			# Shrink first so maximise has something to do
 			session.resize_window(400, 300)
-
+			
 			session.maximize_window
 			rect = session.window_rect
-
+			
 			expect(rect["width"]).to be > 400
 			expect(rect["height"]).to be > 300
 		end
 	end
-
+	
 	with "#fullscreen_window" do
 		it "makes the window fullscreen" do
 			session.visit(bound_url)
-
+			
 			session.resize_window(800, 600)
-
+			
 			begin
 				session.fullscreen_window
 			rescue Async::WebDriver::UnknownCommandError, Async::WebDriver::TimeoutError
 				skip "Fullscreen window is not supported in this environment."
 			end
-
+			
 			rect = session.window_rect
-
+			
 			# Fullscreen dimensions should be at least as large as the pre-fullscreen size
 			expect(rect["width"]).to be >= 800
 			expect(rect["height"]).to be >= 600
@@ -110,10 +110,10 @@ end
 Async::WebDriver::Bridge.each do |klass|
 	name = klass.name.split("::").last
 	pool = Async::WebDriver::Bridge::Pool.new(klass.new)
-
+	
 	describe(klass, unique: name) do
 		include PoolContext
-
+		
 		it_behaves_like AWindow
 	end
 end


### PR DESCRIPTION
## Changes

- Add `Scope::Window` with `#window_rect`, `#resize_window`, `#set_window_rect`, `#maximize_window`, `#minimize_window`, and `#fullscreen_window`.
- Include `Scope::Window` in `Session`.
- Expand `Scope::Printing#print` with full W3C WebDriver parameters: `orientation`, `scale`, `background`, `page`, `margin`, `page_ranges`, and `shrink_to_fit`.

## Tests

- `test/async/webdriver/window.rb` — covers all window management methods across all bridges.
- `test/async/webdriver/printing.rb` — covers all `#print` parameters for Chrome/Firefox; asserts `UnknownCommandError` on Safari since it does not implement the WebDriver print endpoint.