### PR TITLE
Add `Installer::Chrome` for automatic Chrome for Testing installation

### DIFF
--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -22,4 +22,6 @@ def install(version: "stable")
 		browser_path: installation.browser_path,
 		driver_path:  installation.driver_path,
 	)
+	
+	return installation
 end

--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025-2026, by Samuel Williams.
+
+# Install Chrome for Testing and its matching ChromeDriver.
+#
+# Downloads the requested version from the Chrome for Testing infrastructure
+# and caches it in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`).
+# Subsequent calls with the same version are a no-op.
+#
+# @parameter version [String] The version to install: a channel (`stable`, `beta`, `dev`, `canary`),
+#   a major version (e.g. `148`), or an exact version (e.g. `148.0.7778.56`). Default: `stable`.
+def install(version: "stable")
+	require "async/webdriver/installer/chrome"
+	
+	version = version.to_sym if %w[stable beta dev canary].include?(version)
+	
+	installation = Async::WebDriver::Installer::Chrome.install(version)
+	
+	Console.info(self, "Chrome for Testing is ready.",
+		version:      installation.version,
+		platform:     installation.platform,
+		browser_path: installation.browser_path,
+		driver_path:  installation.driver_path,
+	)
+end

--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -6,7 +6,7 @@
 # Install Chrome for Testing and its matching ChromeDriver.
 #
 # Downloads the requested version from the Chrome for Testing infrastructure
-# and caches it in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`).
+# and caches it in `~/.cache/async-webdriver.rb/` (XDG `$XDG_CACHE_HOME`).
 # Subsequent calls with the same version are a no-op.
 #
 # @parameter version [String] The version to install: a channel (`stable`, `beta`, `dev`, `canary`),

--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2025-2026, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 # Install Chrome for Testing and its matching ChromeDriver.
 #

--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -17,10 +17,10 @@ def install(version: "stable")
 	installation = Async::WebDriver::Installer::Chrome.install(version)
 	
 	Console.info(self, "Chrome for Testing is ready.",
-		version:      installation.version,
-		platform:     installation.platform,
+		version: installation.version,
+		platform: installation.platform,
 		browser_path: installation.browser_path,
-		driver_path:  installation.driver_path,
+		driver_path: installation.driver_path,
 	)
 	
 	return installation

--- a/bake/async/webdriver/chrome.rb
+++ b/bake/async/webdriver/chrome.rb
@@ -14,8 +14,6 @@
 def install(version: "stable")
 	require "async/webdriver/installer/chrome"
 	
-	version = version.to_sym if %w[stable beta dev canary].include?(version)
-	
 	installation = Async::WebDriver::Installer::Chrome.install(version)
 	
 	Console.info(self, "Chrome for Testing is ready.",

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -83,13 +83,13 @@ module Async
 				#
 				# @parameter version [Symbol | String] `:stable`, `:beta`, `:dev`, `:canary`,
 				#   a major version string like `"148"`, or an exact version like `"148.0.7778.56"`.
-				# @parameter cache [String] Root of the cache directory.
+				# @parameter cache_path [String] Root of the cache directory.
 				#   Default: `~/.cache/async-webdriver.rb` (XDG-compliant).
 				# @parameter options [Hash] Additional options forwarded to {.new} (e.g. `headless: false`).
 				# @returns [Chrome] A configured bridge.
-				def self.for(version = :stable, cache: Installer.cache_path("chrome"), **options)
+				def self.for(version = :stable, cache_path: Installer.cache_path("chrome"), **options)
 					require_relative "../installer/chrome"
-					installation = Installer::Chrome.find(version, cache: cache) || Installer::Chrome.install(version, cache: cache)
+					installation = Installer::Chrome.find(version, cache_path: cache_path) || Installer::Chrome.install(version, cache_path: cache_path)
 					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
 				end
 				
@@ -99,11 +99,11 @@ module Async
 				# entering the Async reactor.
 				#
 				# @parameter version [Symbol | String] Version specifier — see {.for}.
-				# @parameter cache [String] Root of the cache directory.
+				# @parameter cache_path [String] Root of the cache directory.
 				# @returns [Installer::Chrome::Installation] The installation details.
-				def self.install(version = :stable, cache: Installer.cache_path("chrome"))
+				def self.install(version = :stable, cache_path: Installer.cache_path("chrome"))
 					require_relative "../installer/chrome"
-					Installer::Chrome.install(version, cache: cache)
+					Installer::Chrome.install(version, cache_path: cache_path)
 				end
 				
 				# The path to the Chrome browser executable. If `nil`, ChromeDriver uses its own discovery.

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -89,7 +89,7 @@ module Async
 				# @returns [Chrome] A configured bridge.
 				def self.for(version = :stable, state: Installer::Chrome::DEFAULT_STATE, **options)
 					require_relative "../installer/chrome"
-					installation = Installer::Chrome.install(version, state: state)
+					installation = Installer::Chrome.find(version, state: state) || Installer::Chrome.install(version, state: state)
 					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
 				end
 				

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -93,19 +93,6 @@ module Async
 					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
 				end
 				
-				# Download and install a specific version of Chrome for Testing if not already present.
-				#
-				# Useful in CI setup steps or bake tasks that want to pre-download before
-				# entering the Async reactor.
-				#
-				# @parameter version [Symbol | String] Version specifier — see {.for}.
-				# @parameter cache_path [String] Root of the cache directory.
-				# @returns [Installer::Chrome::Installation] The installation details.
-				def self.install(version = :stable, cache_path: Installer.cache_path("chrome"))
-					require_relative "../installer/chrome"
-					Installer::Chrome.install(version, cache_path: cache_path)
-				end
-				
 				# The path to the Chrome browser executable. If `nil`, ChromeDriver uses its own discovery.
 				# @returns [String | Nil]
 				def browser_path

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -21,13 +21,13 @@ module Async
 			# ```
 			class Chrome < Generic
 				# @returns [String] The path to the `chromedriver` executable.
-				def path
-					@options.fetch(:path, "chromedriver")
+				def driver_path
+					@options.fetch(:driver_path, "chromedriver")
 				end
 				
 				# @returns [String] The version of the `chromedriver` executable.
 				def version
-					::IO.popen([self.path, "--version"]) do |io|
+					::IO.popen([self.driver_path, "--version"]) do |io|
 						return io.read
 					end
 				rescue Errno::ENOENT
@@ -46,7 +46,7 @@ module Async
 					# @returns [Array(String)] The arguments to pass to the `chromedriver` executable.
 					def arguments(**options)
 						[
-							options.fetch(:path, "chromedriver"),
+							options.fetch(:driver_path, "chromedriver"),
 							"--port=#{self.port}",
 						].compact
 					end
@@ -69,21 +69,64 @@ module Async
 					end
 				end
 				
-				# Start the driver.
+				# Start the driver, forwarding the bridge's own options to the driver process
+				# so that a custom `:driver_path` reaches the chromedriver executable.
 				def start(**options)
-					Driver.new(**options).tap(&:start)
+					Driver.new(**@options, **options).tap(&:start)
+				end
+				
+				# Ensure the given version of Chrome for Testing is installed and return a
+				# fully configured {Chrome} bridge pointing at it.
+				#
+				# Delegates to {Async::WebDriver::Installer::Chrome.install} for version
+				# resolution and download, then wraps the result in a configured bridge.
+				#
+				# @parameter version [Symbol | String] `:stable`, `:beta`, `:dev`, `:canary`,
+				#   a major version string like `"148"`, or an exact version like `"148.0.7778.56"`.
+				# @parameter state [String] Root of the state directory.
+				#   Default: `~/.local/state/async-webdriver` (XDG-compliant).
+				# @parameter options [Hash] Additional options forwarded to {.new} (e.g. `headless: false`).
+				# @returns [Chrome] A configured bridge.
+				def self.for(version = :stable, state: Installer::Chrome::DEFAULT_STATE, **options)
+					require_relative "../installer/chrome"
+					installation = Installer::Chrome.install(version, state: state)
+					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
+				end
+				
+				# Download and install a specific version of Chrome for Testing if not already present.
+				#
+				# Useful in CI setup steps or bake tasks that want to pre-download before
+				# entering the Async reactor.
+				#
+				# @parameter version [Symbol | String] Version specifier — see {.for}.
+				# @parameter state [String] Root of the state directory.
+				# @returns [Installer::Chrome::Installation] The installation details.
+				def self.install(version = :stable, state: Installer::Chrome::DEFAULT_STATE)
+					require_relative "../installer/chrome"
+					Installer::Chrome.install(version, state: state)
+				end
+				
+				# The path to the Chrome browser executable. If `nil`, ChromeDriver uses its own discovery.
+				# @returns [String | Nil]
+				def browser_path
+					@options[:browser_path]
 				end
 				
 				# The default capabilities for the Chrome browser which need to be provided when requesting a new session.
 				# @parameter headless [Boolean] Whether to run the browser in headless mode.
+				# @parameter browser_path [String | Nil] Path to the Chrome browser executable. Overrides ChromeDriver's default discovery, useful for pointing at a specific Chrome for Testing installation.
 				# @returns [Hash] The default capabilities for the Chrome browser.
-				def default_capabilities(headless: self.headless?)
+				def default_capabilities(headless: self.headless?, browser_path: self.browser_path)
+					chrome_options = {
+						args: [headless ? "--headless=new" : nil].compact,
+					}
+					
+					chrome_options[:binary] = browser_path if browser_path
+					
 					{
 						alwaysMatch: {
 							browserName: "chrome",
-							"goog:chromeOptions": {
-								args: [headless ? "--headless=new" : nil].compact,
-							},
+							"goog:chromeOptions": chrome_options,
 							webSocketUrl: true,
 						},
 					}

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -83,13 +83,13 @@ module Async
 				#
 				# @parameter version [Symbol | String] `:stable`, `:beta`, `:dev`, `:canary`,
 				#   a major version string like `"148"`, or an exact version like `"148.0.7778.56"`.
-				# @parameter state [String] Root of the state directory.
-				#   Default: `~/.local/state/async-webdriver` (XDG-compliant).
+				# @parameter cache [String] Root of the cache directory.
+				#   Default: `~/.cache/async-webdriver.rb` (XDG-compliant).
 				# @parameter options [Hash] Additional options forwarded to {.new} (e.g. `headless: false`).
 				# @returns [Chrome] A configured bridge.
-				def self.for(version = :stable, state: Installer::Chrome::DEFAULT_CACHE, **options)
+				def self.for(version = :stable, cache: Installer.cache_path("chrome"), **options)
 					require_relative "../installer/chrome"
-					installation = Installer::Chrome.find(version, state: state) || Installer::Chrome.install(version, state: state)
+					installation = Installer::Chrome.find(version, cache: cache) || Installer::Chrome.install(version, cache: cache)
 					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
 				end
 				
@@ -99,11 +99,11 @@ module Async
 				# entering the Async reactor.
 				#
 				# @parameter version [Symbol | String] Version specifier — see {.for}.
-				# @parameter state [String] Root of the state directory.
+				# @parameter cache [String] Root of the cache directory.
 				# @returns [Installer::Chrome::Installation] The installation details.
-				def self.install(version = :stable, state: Installer::Chrome::DEFAULT_CACHE)
+				def self.install(version = :stable, cache: Installer.cache_path("chrome"))
 					require_relative "../installer/chrome"
-					Installer::Chrome.install(version, state: state)
+					Installer::Chrome.install(version, cache: cache)
 				end
 				
 				# The path to the Chrome browser executable. If `nil`, ChromeDriver uses its own discovery.

--- a/lib/async/webdriver/bridge/chrome.rb
+++ b/lib/async/webdriver/bridge/chrome.rb
@@ -87,7 +87,7 @@ module Async
 				#   Default: `~/.local/state/async-webdriver` (XDG-compliant).
 				# @parameter options [Hash] Additional options forwarded to {.new} (e.g. `headless: false`).
 				# @returns [Chrome] A configured bridge.
-				def self.for(version = :stable, state: Installer::Chrome::DEFAULT_STATE, **options)
+				def self.for(version = :stable, state: Installer::Chrome::DEFAULT_CACHE, **options)
 					require_relative "../installer/chrome"
 					installation = Installer::Chrome.find(version, state: state) || Installer::Chrome.install(version, state: state)
 					new(driver_path: installation.driver_path, browser_path: installation.browser_path, **options)
@@ -101,7 +101,7 @@ module Async
 				# @parameter version [Symbol | String] Version specifier — see {.for}.
 				# @parameter state [String] Root of the state directory.
 				# @returns [Installer::Chrome::Installation] The installation details.
-				def self.install(version = :stable, state: Installer::Chrome::DEFAULT_STATE)
+				def self.install(version = :stable, state: Installer::Chrome::DEFAULT_CACHE)
 					require_relative "../installer/chrome"
 					Installer::Chrome.install(version, state: state)
 				end

--- a/lib/async/webdriver/bridge/firefox.rb
+++ b/lib/async/webdriver/bridge/firefox.rb
@@ -20,13 +20,13 @@ module Async
 			# end
 			class Firefox < Generic
 				# @returns [String] The path to the `geckodriver` executable.
-				def path
-					@options.fetch(:path, "geckodriver")
+				def driver_path
+					@options.fetch(:driver_path, "geckodriver")
 				end
 				
 				# @returns [String] The version of the `geckodriver` executable.
 				def version
-					::IO.popen([self.path, "--version"]) do |io|
+					::IO.popen([self.driver_path, "--version"]) do |io|
 						return io.read
 					end
 				rescue Errno::ENOENT
@@ -47,10 +47,10 @@ module Async
 						1
 					end
 					
-					# @returns [Array(String)] The arguments to pass to the `chromedriver` executable.
+					# @returns [Array(String)] The arguments to pass to the `geckodriver` executable.
 					def arguments(**options)
 						[
-							options.fetch(:path, "geckodriver"),
+							options.fetch(:driver_path, "geckodriver"),
 							"--port", self.port.to_s,
 						].compact
 					end
@@ -75,7 +75,7 @@ module Async
 				
 				# Start the driver.
 				def start(**options)
-					Driver.new(**options).tap(&:start)
+					Driver.new(**@options, **options).tap(&:start)
 				end
 				
 				# The default capabilities for the Firefox browser which need to be provided when requesting a new session.

--- a/lib/async/webdriver/bridge/safari.rb
+++ b/lib/async/webdriver/bridge/safari.rb
@@ -21,13 +21,13 @@ module Async
 			# ```
 			class Safari < Generic
 				# @returns [String] The path to the `safaridriver` executable.
-				def path
-					@options.fetch(:path, "safaridriver")
+				def driver_path
+					@options.fetch(:driver_path, "safaridriver")
 				end
 				
 				# @returns [String] The version of the `safaridriver` executable.
 				def version
-					::IO.popen([self.path, "--version"]) do |io|
+					::IO.popen([self.driver_path, "--version"]) do |io|
 						return io.read
 					end
 				rescue Errno::ENOENT
@@ -46,7 +46,7 @@ module Async
 					# @returns [Array(String)] The arguments to pass to the `safaridriver` executable.
 					def arguments(**options)
 						[
-							options.fetch(:path, "safaridriver"),
+							options.fetch(:driver_path, "safaridriver"),
 							"--port=#{self.port}",
 						].compact
 					end
@@ -71,7 +71,7 @@ module Async
 				
 				# Start the driver.
 				def start(**options)
-					Driver.new(**options).tap(&:start)
+					Driver.new(**@options, **options).tap(&:start)
 				end
 				
 				# The default capabilities for the Safari browser which need to be provided when requesting a new session.

--- a/lib/async/webdriver/installer.rb
+++ b/lib/async/webdriver/installer.rb
@@ -29,7 +29,7 @@ module Async
 				if subdirectory
 					path = File.join(path, subdirectory)
 				end
-
+				
 				return path
 			end
 		end

--- a/lib/async/webdriver/installer.rb
+++ b/lib/async/webdriver/installer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require_relative "installer/chrome"
+
+module Async
+	module WebDriver
+		# Browser installation and management for automated testing.
+		#
+		# Each browser has its own sub-module with browser-specific platform detection,
+		# version resolution, and download logic:
+		#
+		# - {Installer::Chrome} — Chrome for Testing, via the Chrome for Testing JSON API.
+		module Installer
+		end
+	end
+end

--- a/lib/async/webdriver/installer.rb
+++ b/lib/async/webdriver/installer.rb
@@ -24,8 +24,13 @@ module Async
 			# @parameter env [Hash] Environment to read `XDG_CACHE_HOME` from. Default: `ENV`.
 			# @returns [String] Absolute path.
 			def self.cache_path(subdirectory = nil, env = ENV)
-				base = File.expand_path("async-webdriver.rb", env.fetch("XDG_CACHE_HOME", "~/.cache"))
-				subdirectory ? File.join(base, subdirectory) : base
+				path = File.expand_path("async-webdriver.rb", env.fetch("XDG_CACHE_HOME", "~/.cache"))
+				
+				if subdirectory
+					path = File.join(path, subdirectory)
+				end
+
+				return path
 			end
 		end
 	end

--- a/lib/async/webdriver/installer.rb
+++ b/lib/async/webdriver/installer.rb
@@ -14,6 +14,19 @@ module Async
 		#
 		# - {Installer::Chrome} — Chrome for Testing, via the Chrome for Testing JSON API.
 		module Installer
+			# Resolve the cache path for the given sub-directory.
+			#
+			# Follows the XDG Base Directory Specification, using `$XDG_CACHE_HOME`
+			# (default: `~/.cache`) as the root, with `async-webdriver.rb` as the
+			# application directory.
+			#
+			# @parameter subdirectory [String | Nil] Optional sub-directory, e.g. `"chrome"`.
+			# @parameter env [Hash] Environment to read `XDG_CACHE_HOME` from. Default: `ENV`.
+			# @returns [String] Absolute path.
+			def self.cache_path(subdirectory = nil, env = ENV)
+				base = File.expand_path("async-webdriver.rb", env.fetch("XDG_CACHE_HOME", "~/.cache"))
+				subdirectory ? File.join(base, subdirectory) : base
+			end
 		end
 	end
 end

--- a/lib/async/webdriver/installer.rb
+++ b/lib/async/webdriver/installer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require_relative "installer/chrome"
 

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require_relative "chrome/platform"
 require_relative "chrome/releases"

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -38,9 +38,7 @@ module Async
 			# ```
 			module Chrome
 				# Default state directory, following the XDG Base Directory Specification.
-				DEFAULT_STATE = File.expand_path(
-					File.join(ENV.fetch("XDG_STATE_HOME", "~/.local/state"), "async-webdriver")
-				).freeze
+				DEFAULT_STATE = File.expand_path("async-webdriver", ENV.fetch("XDG_STATE_HOME", "~/.local/state")).freeze
 				
 				# Ensure the given version is installed and return an {Installation}.
 				#

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -18,8 +18,8 @@ module Async
 			# - A major version string: `"148"` (resolves to the latest patch)
 			# - An exact version string: `"148.0.7778.56"`
 			#
-			# Installations are cached in `~/.local/state/async-webdriver/` by default
-			# (respects `$XDG_STATE_HOME`).
+			# Installations are cached in `~/.cache/async-webdriver.rb/` by default
+			# (respects `$XDG_CACHE_HOME`).
 			#
 			# ## Example
 			#
@@ -37,8 +37,8 @@ module Async
 			# bridge = Async::WebDriver::Bridge::Chrome.for(:stable)
 			# ```
 			module Chrome
-				# Default state directory, following the XDG Base Directory Specification.
-				DEFAULT_STATE = File.expand_path("async-webdriver", ENV.fetch("XDG_STATE_HOME", "~/.local/state")).freeze
+				# Default cache directory, following the XDG Base Directory Specification.
+				DEFAULT_CACHE = File.expand_path("async-webdriver.rb", ENV.fetch("XDG_CACHE_HOME", "~/.cache")).freeze
 				
 				# Ensure the given version is installed and return an {Installation}.
 				#
@@ -46,19 +46,19 @@ module Async
 				# infrastructure only when the version is not already present.
 				#
 				# @parameter version [Symbol | String] Version specifier.
-				# @parameter state [String] Root of the state directory.
+				# @parameter cache [String] Root of the cache directory.
 				# @returns [Installation]
-				def self.install(version = :stable, state: DEFAULT_STATE)
-					Installation.install(version, state: state)
+				def self.install(version = :stable, cache: DEFAULT_CACHE)
+					Installation.install(version, cache: cache)
 				end
 				
 				# Find an already-installed version or channel without hitting the network.
 				#
 				# @parameter version [Symbol | String] Channel or exact version string.
-				# @parameter state [String] Root of the state directory.
+				# @parameter cache [String] Root of the cache directory.
 				# @returns [Installation | Nil]
-				def self.find(version, state: DEFAULT_STATE)
-					Installation.find(version, Platform.current, state: state)
+				def self.find(version, cache: DEFAULT_CACHE)
+					Installation.find(version, Platform.current, cache: cache)
 				end
 			end
 		end

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -38,7 +38,7 @@ module Async
 			# ```
 			module Chrome
 				# Default cache directory, following the XDG Base Directory Specification.
-				DEFAULT_CACHE = File.expand_path("async-webdriver.rb", ENV.fetch("XDG_CACHE_HOME", "~/.cache")).freeze
+				
 				
 				# Ensure the given version is installed and return an {Installation}.
 				#
@@ -48,7 +48,7 @@ module Async
 				# @parameter version [Symbol | String] Version specifier.
 				# @parameter cache [String] Root of the cache directory.
 				# @returns [Installation]
-				def self.install(version = :stable, cache: DEFAULT_CACHE)
+				def self.install(version = :stable, cache: Installer.cache_path("chrome"))
 					Installation.install(version, cache: cache)
 				end
 				
@@ -57,7 +57,7 @@ module Async
 				# @parameter version [Symbol | String] Channel or exact version string.
 				# @parameter cache [String] Root of the cache directory.
 				# @returns [Installation | Nil]
-				def self.find(version, cache: DEFAULT_CACHE)
+				def self.find(version, cache: Installer.cache_path("chrome"))
 					Installation.find(version, Platform.current, cache: cache)
 				end
 			end

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -54,9 +54,9 @@ module Async
 					Installation.install(version, state: state)
 				end
 				
-				# Find an already-installed version without hitting the network.
+				# Find an already-installed version or channel without hitting the network.
 				#
-				# @parameter version [String] Exact version string, e.g. `"148.0.7778.56"`.
+				# @parameter version [Symbol | String] Channel or exact version string.
 				# @parameter state [String] Root of the state directory.
 				# @returns [Installation | Nil]
 				def self.find(version, state: DEFAULT_STATE)

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -46,19 +46,19 @@ module Async
 				# infrastructure only when the version is not already present.
 				#
 				# @parameter version [Symbol | String] Version specifier.
-				# @parameter cache [String] Root of the cache directory.
+				# @parameter cache_path [String] Root of the cache directory.
 				# @returns [Installation]
-				def self.install(version = :stable, cache: Installer.cache_path("chrome"))
-					Installation.install(version, cache: cache)
+				def self.install(version = :stable, cache_path: Installer.cache_path("chrome"))
+					Installation.install(version, cache_path: cache_path)
 				end
 				
 				# Find an already-installed version or channel without hitting the network.
 				#
 				# @parameter version [Symbol | String] Channel or exact version string.
-				# @parameter cache [String] Root of the cache directory.
+				# @parameter cache_path [String] Root of the cache directory.
 				# @returns [Installation | Nil]
-				def self.find(version, cache: Installer.cache_path("chrome"))
-					Installation.find(version, Platform.current, cache: cache)
+				def self.find(version, cache_path: Installer.cache_path("chrome"))
+					Installation.find(version, Platform.current, cache_path: cache_path)
 				end
 			end
 		end

--- a/lib/async/webdriver/installer/chrome.rb
+++ b/lib/async/webdriver/installer/chrome.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require_relative "chrome/platform"
+require_relative "chrome/releases"
+require_relative "chrome/installation"
+
+module Async
+	module WebDriver
+		module Installer
+			# Installer for Chrome for Testing, the purpose-built Chrome variant
+			# designed for automated testing.
+			#
+			# Versions can be specified as:
+			# - A channel symbol: `:stable`, `:beta`, `:dev`, `:canary`
+			# - A major version string: `"148"` (resolves to the latest patch)
+			# - An exact version string: `"148.0.7778.56"`
+			#
+			# Installations are cached in `~/.local/state/async-webdriver/` by default
+			# (respects `$XDG_STATE_HOME`).
+			#
+			# ## Example
+			#
+			# ``` ruby
+			# installation = Async::WebDriver::Installer::Chrome.install(:stable)
+			# bridge = Async::WebDriver::Bridge::Chrome.new(
+			#   driver_path:  installation.driver_path,
+			#   browser_path: installation.browser_path,
+			# )
+			# ```
+			#
+			# Or via the convenience shorthand on the bridge:
+			#
+			# ``` ruby
+			# bridge = Async::WebDriver::Bridge::Chrome.for(:stable)
+			# ```
+			module Chrome
+				# Default state directory, following the XDG Base Directory Specification.
+				DEFAULT_STATE = File.expand_path(
+					File.join(ENV.fetch("XDG_STATE_HOME", "~/.local/state"), "async-webdriver")
+				).freeze
+				
+				# Ensure the given version is installed and return an {Installation}.
+				#
+				# Checks the local cache first; downloads from the Chrome for Testing
+				# infrastructure only when the version is not already present.
+				#
+				# @parameter version [Symbol | String] Version specifier.
+				# @parameter state [String] Root of the state directory.
+				# @returns [Installation]
+				def self.install(version = :stable, state: DEFAULT_STATE)
+					Installation.install(version, state: state)
+				end
+				
+				# Find an already-installed version without hitting the network.
+				#
+				# @parameter version [String] Exact version string, e.g. `"148.0.7778.56"`.
+				# @parameter state [String] Root of the state directory.
+				# @returns [Installation | Nil]
+				def self.find(version, state: DEFAULT_STATE)
+					Installation.find(version, Platform.current, state: state)
+				end
+			end
+		end
+	end
+end

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -20,10 +20,20 @@ module Async
 				# 	{state}/{platform}/{version}/
 				# 	  chrome/       ← extracted chrome zip contents
 				# 	  chromedriver/ ← extracted chromedriver zip contents
+				#
+				# Channel names (e.g. `stable`) are stored as symlinks pointing at the
+				# specific version directory, so that {find} can resolve them without
+				# hitting the network. {install} always re-checks the API and updates
+				# the symlink if the channel has moved on to a newer version.
 				class Installation
 					# Look up an existing installation, or download and install a fresh one.
 					#
-					# @parameter version [Symbol | String] Channel or version specifier — see {Async::WebDriver::Bridge::Chrome.for}.
+					# For channel specifiers (`:stable`, `:beta`, etc.), always hits the
+					# Chrome for Testing API to resolve the current version, downloads if
+					# needed, and updates the channel symlink. For exact versions, checks
+					# the local cache only.
+					#
+					# @parameter version [Symbol | String] Channel or version specifier.
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation]
 					def self.install(version, state:)
@@ -50,29 +60,30 @@ module Async
 							end
 						end
 						
+						# Update the channel symlink so subsequent find(:stable) calls
+						# resolve locally without a network request.
+						if channel = channel_name(version)
+							update_channel_symlink(channel, release[:version], platform, state: state)
+						end
+						
 						return installation
 					end
 					
-					# Find an already-installed version, without hitting the network.
+					# Find an already-installed version or channel, without hitting the network.
 					#
-					# @parameter version [String] Exact version, e.g. `"148.0.7778.56"`.
+					# For channel names (`:stable`, `"stable"`, etc.), resolves the local
+					# symlink. For exact versions, checks the installation directory directly.
+					#
+					# @parameter version [Symbol | String] Channel or exact version string.
 					# @parameter platform [String] Platform string, e.g. `"mac-arm64"`.
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation | Nil]
 					def self.find(version, platform, state:)
-						dir = installation_dir(version, platform, state: state)
-						
-						browser_path = File.join(dir, "chrome", Platform.chrome_binary(platform))
-						driver_path = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
-						
-						return nil unless File.exist?(browser_path) && File.exist?(driver_path)
-						
-						new(
-							browser_path: browser_path,
-							driver_path: driver_path,
-							version: version,
-							platform: platform,
-						)
+						if channel = channel_name(version)
+							find_channel(channel, platform, state: state)
+						else
+							find_version(version, platform, state: state)
+						end
 					end
 					
 					# @parameter browser_path [String] Absolute path to the Chrome browser executable.
@@ -97,6 +108,51 @@ module Async
 					
 					# @attribute [String] Platform, e.g. `"mac-arm64"`.
 					attr :platform
+					
+					private_class_method def self.channel_name(version)
+						Releases::CHANNELS.key(version.to_s.capitalize) && version.to_s.downcase
+					end
+					
+					private_class_method def self.find_channel(channel, platform, state:)
+						symlink = channel_symlink(channel, platform, state: state)
+						return nil unless File.symlink?(symlink)
+						
+						# Derive the version from the symlink target name.
+						version = File.basename(File.readlink(symlink))
+						find_version(version, platform, state: state)
+					end
+					
+					private_class_method def self.find_version(version, platform, state:)
+						dir = installation_dir(version, platform, state: state)
+						
+						browser_path = File.join(dir, "chrome", Platform.chrome_binary(platform))
+						driver_path = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
+						
+						return nil unless File.exist?(browser_path) && File.exist?(driver_path)
+						
+						new(
+							browser_path: browser_path,
+							driver_path: driver_path,
+							version: version,
+							platform: platform,
+						)
+					end
+					
+					private_class_method def self.update_channel_symlink(channel, version, platform, state:)
+						symlink = channel_symlink(channel, platform, state: state)
+						target = installation_dir(version, platform, state: state)
+						
+						# Remove stale symlink if it points elsewhere.
+						if File.symlink?(symlink) && File.readlink(symlink) != target
+							File.unlink(symlink)
+						end
+						
+						File.symlink(target, symlink) unless File.symlink?(symlink)
+					end
+					
+					private_class_method def self.channel_symlink(channel, platform, state:)
+						File.join(state, platform, channel.to_s)
+					end
 					
 					private_class_method def self.installation_dir(version, platform, state:)
 						File.join(state, platform, version)

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -27,26 +27,25 @@ module Async
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation]
 					def self.install(version, state:)
-						
 						platform = Platform.current
-						info     = Releases.resolve(version, platform)
+						release = Releases.resolve(version, platform)
 						
-						existing = find(info[:version], platform, state: state)
+						existing = find(release[:version], platform, state: state)
 						return existing if existing
 						
-						Console.info(self, "Installing Chrome for Testing #{info[:version]}...", platform: platform)
+						Console.info(self, "Installing Chrome for Testing #{release[:version]}...", platform: platform)
 						
-						dir = installation_dir(info[:version], platform, state: state)
+						dir = installation_dir(release[:version], platform, state: state)
 						FileUtils.mkdir_p(dir)
 						
 						begin
-							download_and_extract(info[:chrome_url],      File.join(dir, "chrome"))
-							download_and_extract(info[:chromedriver_url], File.join(dir, "chromedriver"))
+							download_and_extract(release[:chrome_url], File.join(dir, "chrome"))
+							download_and_extract(release[:chromedriver_url], File.join(dir, "chromedriver"))
 							
-							installation = find(info[:version], platform, state: state) or
+							installation = find(release[:version], platform, state: state) or
 								raise "Installation failed: binaries not found after extraction"
 							
-							Console.info(self, "Installed Chrome for Testing #{info[:version]}.", platform: platform)
+							Console.info(self, "Installed Chrome for Testing #{release[:version]}.", platform: platform)
 							
 							installation
 						rescue
@@ -62,19 +61,18 @@ module Async
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation | Nil]
 					def self.find(version, platform, state:)
-						
 						dir = installation_dir(version, platform, state: state)
 						
-						browser_path = File.join(dir, "chrome",      Platform.chrome_binary(platform))
-						driver_path  = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
+						browser_path = File.join(dir, "chrome", Platform.chrome_binary(platform))
+						driver_path = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
 						
 						return nil unless File.exist?(browser_path) && File.exist?(driver_path)
 						
 						new(
 							browser_path: browser_path,
-							driver_path:  driver_path,
-							version:           version,
-							platform:          platform,
+							driver_path: driver_path,
+							version: version,
+							platform: platform,
 						)
 					end
 					
@@ -84,9 +82,9 @@ module Async
 					# @parameter platform [String] Platform string.
 					def initialize(browser_path:, driver_path:, version:, platform:)
 						@browser_path = browser_path
-						@driver_path  = driver_path
-						@version      = version
-						@platform     = platform
+						@driver_path = driver_path
+						@version = version
+						@platform = platform
 					end
 					
 					# @attribute [String] Absolute path to the Chrome browser executable.

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require "fileutils"
 require "tempfile"

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -34,7 +34,7 @@ module Async
 					# the local cache only.
 					#
 					# @parameter version [Symbol | String] Channel or version specifier.
-					# @parameter cache_path [String] Root of the cache_path directory.
+					# @parameter cache_path [String] Root of the cache directory.
 					# @returns [Installation]
 					def self.install(version, cache_path:)
 						platform = Platform.current
@@ -76,7 +76,7 @@ module Async
 					#
 					# @parameter version [Symbol | String] Channel or exact version string.
 					# @parameter platform [String] Platform string, e.g. `"mac-arm64"`.
-					# @parameter cache_path [String] Root of the cache_path directory.
+					# @parameter cache_path [String] Root of the cache directory.
 					# @returns [Installation | Nil]
 					def self.find(version, platform, cache_path:)
 						if channel = channel_name(version)

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "fileutils"
+require "tempfile"
+
+module Async
+	module WebDriver
+		module Installer
+			module Chrome
+				# Represents a Chrome for Testing installation on disk, and provides class-level
+				# methods for resolving, locating, and downloading installations.
+				#
+				# Installations are stored under the state directory, organised as:
+				#
+				# 	{state}/{platform}/{version}/
+				# 	  chrome/       ← extracted chrome zip contents
+				# 	  chromedriver/ ← extracted chromedriver zip contents
+				class Installation
+					# Look up an existing installation, or download and install a fresh one.
+					#
+					# @parameter version [Symbol | String] Channel or version specifier — see {Async::WebDriver::Bridge::Chrome.for}.
+					# @parameter state [String] Root of the state directory.
+					# @returns [Installation]
+					def self.install(version, state:)
+						require_relative "platform"
+						require_relative "releases"
+						
+						platform = Platform.current
+						info     = Releases.resolve(version, platform)
+						
+						existing = find(info[:version], platform, state: state)
+						return existing if existing
+						
+						Console.info(self, "Installing Chrome for Testing #{info[:version]}...", platform: platform)
+						
+						dir = installation_dir(info[:version], platform, state: state)
+						FileUtils.mkdir_p(dir)
+						
+						begin
+							download_and_extract(info[:chrome_url],      File.join(dir, "chrome"))
+							download_and_extract(info[:chromedriver_url], File.join(dir, "chromedriver"))
+							
+							installation = find(info[:version], platform, state: state) or
+								raise "Installation failed: binaries not found after extraction"
+							
+							Console.info(self, "Installed Chrome for Testing #{info[:version]}.", platform: platform)
+							
+							installation
+						rescue
+							FileUtils.rm_rf(dir)
+							raise
+						end
+					end
+					
+					# Find an already-installed version, without hitting the network.
+					#
+					# @parameter version [String] Exact version, e.g. `"148.0.7778.56"`.
+					# @parameter platform [String] Platform string, e.g. `"mac-arm64"`.
+					# @parameter state [String] Root of the state directory.
+					# @returns [Installation | Nil]
+					def self.find(version, platform, state:)
+						require_relative "platform"
+						
+						dir = installation_dir(version, platform, state: state)
+						
+						browser_path = File.join(dir, "chrome",      Platform.chrome_binary(platform))
+						driver_path  = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
+						
+						return nil unless File.exist?(browser_path) && File.exist?(driver_path)
+						
+						new(
+							browser_path: browser_path,
+							driver_path:  driver_path,
+							version:           version,
+							platform:          platform,
+						)
+					end
+					
+					# @parameter browser_path [String] Absolute path to the Chrome browser executable.
+					# @parameter driver_path [String] Absolute path to the chromedriver executable.
+					# @parameter version [String] Exact version string.
+					# @parameter platform [String] Platform string.
+					def initialize(browser_path:, driver_path:, version:, platform:)
+						@browser_path = browser_path
+						@driver_path  = driver_path
+						@version      = version
+						@platform     = platform
+					end
+					
+					# @attribute [String] Absolute path to the Chrome browser executable.
+					attr :browser_path
+					
+					# @attribute [String] Absolute path to the chromedriver executable.
+					attr :driver_path
+					
+					# @attribute [String] Exact installed version, e.g. `"148.0.7778.56"`.
+					attr :version
+					
+					# @attribute [String] Platform, e.g. `"mac-arm64"`.
+					attr :platform
+					
+					private_class_method def self.installation_dir(version, platform, state:)
+						File.join(state, platform, version)
+					end
+					
+					private_class_method def self.download_and_extract(url, dest)
+						require "async/http/internet"
+						
+						Tempfile.create(["async-webdriver-", ".zip"]) do |tmp|
+							tmp.binmode
+							
+							Sync do
+								internet = Async::HTTP::Internet.new
+								begin
+									Console.debug(self, "Downloading...", url: url)
+									response = internet.get(url)
+									tmp.write(response.read)
+									tmp.flush
+								ensure
+									internet.close
+								end
+							end
+							
+							FileUtils.mkdir_p(dest)
+							system("unzip", "-q", "-o", tmp.path, "-d", dest) or
+								raise "Failed to extract #{url}"
+							
+							# Remove macOS quarantine attributes added to files downloaded via code.
+							if RUBY_PLATFORM.include?("darwin")
+								system("xattr", "-r", "-d", "com.apple.quarantine", dest)
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -15,9 +15,9 @@ module Async
 				# Represents a Chrome for Testing installation on disk, and provides class-level
 				# methods for resolving, locating, and downloading installations.
 				#
-				# Installations are stored under the state directory, organised as:
+				# Installations are stored under the cache_path directory, organised as:
 				#
-				# 	{state}/{platform}/{version}/
+				# 	{cache_path}/{platform}/{version}/
 				# 	  chrome/       ← extracted chrome zip contents
 				# 	  chromedriver/ ← extracted chromedriver zip contents
 				#
@@ -34,23 +34,23 @@ module Async
 					# the local cache only.
 					#
 					# @parameter version [Symbol | String] Channel or version specifier.
-					# @parameter state [String] Root of the state directory.
+					# @parameter cache_path [String] Root of the cache_path directory.
 					# @returns [Installation]
-					def self.install(version, state:)
+					def self.install(version, cache_path:)
 						platform = Platform.current
 						release = Releases.resolve(version, platform)
 						
-						unless installation = find(release[:version], platform, state: state)
+						unless installation = find(release[:version], platform, cache_path: cache_path)
 							Console.info(self, "Installing Chrome for Testing #{release[:version]}...", platform: platform)
 							
-							dir = installation_dir(release[:version], platform, state: state)
+							dir = installation_dir(release[:version], platform, cache_path: cache_path)
 							FileUtils.mkdir_p(dir)
 							
 							begin
 								download_and_extract(release[:chrome_url], File.join(dir, "chrome"))
 								download_and_extract(release[:chromedriver_url], File.join(dir, "chromedriver"))
 								
-								installation = find(release[:version], platform, state: state) or
+								installation = find(release[:version], platform, cache_path: cache_path) or
 									raise "Installation failed: binaries not found after extraction"
 								
 								Console.info(self, "Installed Chrome for Testing #{release[:version]}.", platform: platform)
@@ -63,7 +63,7 @@ module Async
 						# Update the channel symlink so subsequent find(:stable) calls
 						# resolve locally without a network request.
 						if channel = channel_name(version)
-							update_channel_symlink(channel, release[:version], platform, state: state)
+							update_channel_symlink(channel, release[:version], platform, cache_path: cache_path)
 						end
 						
 						return installation
@@ -76,13 +76,13 @@ module Async
 					#
 					# @parameter version [Symbol | String] Channel or exact version string.
 					# @parameter platform [String] Platform string, e.g. `"mac-arm64"`.
-					# @parameter state [String] Root of the state directory.
+					# @parameter cache_path [String] Root of the cache_path directory.
 					# @returns [Installation | Nil]
-					def self.find(version, platform, state:)
+					def self.find(version, platform, cache_path:)
 						if channel = channel_name(version)
-							find_channel(channel, platform, state: state)
+							find_channel(channel, platform, cache_path: cache_path)
 						else
-							find_version(version, platform, state: state)
+							find_version(version, platform, cache_path: cache_path)
 						end
 					end
 					
@@ -113,17 +113,17 @@ module Async
 						Releases::CHANNELS.key(version.to_s.capitalize) && version.to_s.downcase
 					end
 					
-					private_class_method def self.find_channel(channel, platform, state:)
-						symlink = channel_symlink(channel, platform, state: state)
+					private_class_method def self.find_channel(channel, platform, cache_path:)
+						symlink = channel_symlink(channel, platform, cache_path: cache_path)
 						return nil unless File.symlink?(symlink)
 						
 						# Derive the version from the symlink target name.
 						version = File.basename(File.readlink(symlink))
-						find_version(version, platform, state: state)
+						find_version(version, platform, cache_path: cache_path)
 					end
 					
-					private_class_method def self.find_version(version, platform, state:)
-						dir = installation_dir(version, platform, state: state)
+					private_class_method def self.find_version(version, platform, cache_path:)
+						dir = installation_dir(version, platform, cache_path: cache_path)
 						
 						browser_path = File.join(dir, "chrome", Platform.chrome_binary(platform))
 						driver_path = File.join(dir, "chromedriver", Platform.chromedriver_binary(platform))
@@ -138,9 +138,9 @@ module Async
 						)
 					end
 					
-					private_class_method def self.update_channel_symlink(channel, version, platform, state:)
-						symlink = channel_symlink(channel, platform, state: state)
-						target = installation_dir(version, platform, state: state)
+					private_class_method def self.update_channel_symlink(channel, version, platform, cache_path:)
+						symlink = channel_symlink(channel, platform, cache_path: cache_path)
+						target = installation_dir(version, platform, cache_path: cache_path)
 						
 						# Remove stale symlink if it points elsewhere.
 						if File.symlink?(symlink) && File.readlink(symlink) != target
@@ -150,12 +150,12 @@ module Async
 						File.symlink(target, symlink) unless File.symlink?(symlink)
 					end
 					
-					private_class_method def self.channel_symlink(channel, platform, state:)
-						File.join(state, platform, channel.to_s)
+					private_class_method def self.channel_symlink(channel, platform, cache_path:)
+						File.join(cache_path, platform, channel.to_s)
 					end
 					
-					private_class_method def self.installation_dir(version, platform, state:)
-						File.join(state, platform, version)
+					private_class_method def self.installation_dir(version, platform, cache_path:)
+						File.join(cache_path, platform, version)
 					end
 					
 					private_class_method def self.download_and_extract(url, dest)

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -5,6 +5,8 @@
 
 require "fileutils"
 require "tempfile"
+require_relative "platform"
+require_relative "releases"
 
 module Async
 	module WebDriver
@@ -25,8 +27,6 @@ module Async
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation]
 					def self.install(version, state:)
-						require_relative "platform"
-						require_relative "releases"
 						
 						platform = Platform.current
 						info     = Releases.resolve(version, platform)
@@ -62,7 +62,6 @@ module Async
 					# @parameter state [String] Root of the state directory.
 					# @returns [Installation | Nil]
 					def self.find(version, platform, state:)
-						require_relative "platform"
 						
 						dir = installation_dir(version, platform, state: state)
 						

--- a/lib/async/webdriver/installer/chrome/installation.rb
+++ b/lib/async/webdriver/installer/chrome/installation.rb
@@ -30,28 +30,27 @@ module Async
 						platform = Platform.current
 						release = Releases.resolve(version, platform)
 						
-						existing = find(release[:version], platform, state: state)
-						return existing if existing
-						
-						Console.info(self, "Installing Chrome for Testing #{release[:version]}...", platform: platform)
-						
-						dir = installation_dir(release[:version], platform, state: state)
-						FileUtils.mkdir_p(dir)
-						
-						begin
-							download_and_extract(release[:chrome_url], File.join(dir, "chrome"))
-							download_and_extract(release[:chromedriver_url], File.join(dir, "chromedriver"))
+						unless installation = find(release[:version], platform, state: state)
+							Console.info(self, "Installing Chrome for Testing #{release[:version]}...", platform: platform)
 							
-							installation = find(release[:version], platform, state: state) or
-								raise "Installation failed: binaries not found after extraction"
+							dir = installation_dir(release[:version], platform, state: state)
+							FileUtils.mkdir_p(dir)
 							
-							Console.info(self, "Installed Chrome for Testing #{release[:version]}.", platform: platform)
-							
-							installation
-						rescue
-							FileUtils.rm_rf(dir)
-							raise
+							begin
+								download_and_extract(release[:chrome_url], File.join(dir, "chrome"))
+								download_and_extract(release[:chromedriver_url], File.join(dir, "chromedriver"))
+								
+								installation = find(release[:version], platform, state: state) or
+									raise "Installation failed: binaries not found after extraction"
+								
+								Console.info(self, "Installed Chrome for Testing #{release[:version]}.", platform: platform)
+							rescue
+								FileUtils.rm_rf(dir)
+								raise
+							end
 						end
+						
+						return installation
 					end
 					
 					# Find an already-installed version, without hitting the network.

--- a/lib/async/webdriver/installer/chrome/platform.rb
+++ b/lib/async/webdriver/installer/chrome/platform.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 module Async
 	module WebDriver

--- a/lib/async/webdriver/installer/chrome/platform.rb
+++ b/lib/async/webdriver/installer/chrome/platform.rb
@@ -37,13 +37,20 @@ module Async
 					# @returns [String]
 					def self.chrome_binary(platform)
 						case platform
-						when "mac-arm64"  then "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
-						when "mac-x64"    then "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
-						when "linux64"    then "chrome-linux64/chrome"
-						when "linux-arm64" then "chrome-linux-arm64/chrome"
-						when "win64"      then "chrome-win64/chrome.exe"
-						when "win32"      then "chrome-win32/chrome.exe"
-						else raise "Unknown platform: #{platform}"
+						when "mac-arm64"
+							"chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+						when "mac-x64"
+							"chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+						when "linux64"
+							"chrome-linux64/chrome"
+						when "linux-arm64"
+							"chrome-linux-arm64/chrome"
+						when "win64"
+							"chrome-win64/chrome.exe"
+						when "win32"
+							"chrome-win32/chrome.exe"
+						else
+							raise "Unknown platform: #{platform}"
 						end
 					end
 					
@@ -52,13 +59,20 @@ module Async
 					# @returns [String]
 					def self.chromedriver_binary(platform)
 						case platform
-						when "mac-arm64"  then "chromedriver-mac-arm64/chromedriver"
-						when "mac-x64"    then "chromedriver-mac-x64/chromedriver"
-						when "linux64"    then "chromedriver-linux64/chromedriver"
-						when "linux-arm64" then "chromedriver-linux-arm64/chromedriver"
-						when "win64"      then "chromedriver-win64/chromedriver.exe"
-						when "win32"      then "chromedriver-win32/chromedriver.exe"
-						else raise "Unknown platform: #{platform}"
+						when "mac-arm64"
+							"chromedriver-mac-arm64/chromedriver"
+						when "mac-x64"
+							"chromedriver-mac-x64/chromedriver"
+						when "linux64"
+							"chromedriver-linux64/chromedriver"
+						when "linux-arm64"
+							"chromedriver-linux-arm64/chromedriver"
+						when "win64"
+							"chromedriver-win64/chromedriver.exe"
+						when "win32"
+							"chromedriver-win32/chromedriver.exe"
+						else
+							raise "Unknown platform: #{platform}"
 						end
 					end
 				end

--- a/lib/async/webdriver/installer/chrome/platform.rb
+++ b/lib/async/webdriver/installer/chrome/platform.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+module Async
+	module WebDriver
+		module Installer
+			module Chrome
+				# Platform detection for Chrome for Testing downloads.
+				#
+				# Maps Ruby's `RUBY_PLATFORM` to the platform strings used by the
+				# Chrome for Testing JSON API and zip file naming conventions.
+				module Platform
+					# Ordered list of (pattern, platform) pairs. First match wins.
+					PLATFORM_MAP = [
+						[/arm.*darwin|darwin.*arm|aarch64.*darwin|darwin.*aarch64/, "mac-arm64"],
+						[/darwin/,                                                   "mac-x64"],
+						[/aarch64.*linux|linux.*aarch64/,                           "linux-arm64"],
+						[/linux/,                                                    "linux64"],
+						[/x64.*mingw|mingw.*x64/,                                   "win64"],
+						[/mingw/,                                                    "win32"],
+					].freeze
+					
+					# Detect the current platform.
+					# @returns [String] e.g. `"mac-arm64"`, `"linux64"`.
+					# @raises [RuntimeError] If the platform is not recognised.
+					def self.current
+						PLATFORM_MAP.each do |pattern, platform|
+							return platform if RUBY_PLATFORM.match?(pattern)
+						end
+						raise "Unsupported platform: #{RUBY_PLATFORM}"
+					end
+					
+					# Relative path to the Chrome binary inside the extracted chrome zip.
+					# @parameter platform [String]
+					# @returns [String]
+					def self.chrome_binary(platform)
+						case platform
+						when "mac-arm64"  then "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+						when "mac-x64"    then "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+						when "linux64"    then "chrome-linux64/chrome"
+						when "linux-arm64" then "chrome-linux-arm64/chrome"
+						when "win64"      then "chrome-win64/chrome.exe"
+						when "win32"      then "chrome-win32/chrome.exe"
+						else raise "Unknown platform: #{platform}"
+						end
+					end
+					
+					# Relative path to the chromedriver binary inside the extracted chromedriver zip.
+					# @parameter platform [String]
+					# @returns [String]
+					def self.chromedriver_binary(platform)
+						case platform
+						when "mac-arm64"  then "chromedriver-mac-arm64/chromedriver"
+						when "mac-x64"    then "chromedriver-mac-x64/chromedriver"
+						when "linux64"    then "chromedriver-linux64/chromedriver"
+						when "linux-arm64" then "chromedriver-linux-arm64/chromedriver"
+						when "win64"      then "chromedriver-win64/chromedriver.exe"
+						when "win32"      then "chromedriver-win32/chromedriver.exe"
+						else raise "Unknown platform: #{platform}"
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/lib/async/webdriver/installer/chrome/platform.rb
+++ b/lib/async/webdriver/installer/chrome/platform.rb
@@ -15,11 +15,11 @@ module Async
 					# Ordered list of (pattern, platform) pairs. First match wins.
 					PLATFORM_MAP = [
 						[/arm.*darwin|darwin.*arm|aarch64.*darwin|darwin.*aarch64/, "mac-arm64"],
-						[/darwin/,                                                   "mac-x64"],
-						[/aarch64.*linux|linux.*aarch64/,                           "linux-arm64"],
-						[/linux/,                                                    "linux64"],
-						[/x64.*mingw|mingw.*x64/,                                   "win64"],
-						[/mingw/,                                                    "win32"],
+						[/darwin/, "mac-x64"],
+						[/aarch64.*linux|linux.*aarch64/, "linux-arm64"],
+						[/linux/, "linux64"],
+						[/x64.*mingw|mingw.*x64/, "win64"],
+						[/mingw/, "win32"],
 					].freeze
 					
 					# Detect the current platform.

--- a/lib/async/webdriver/installer/chrome/releases.rb
+++ b/lib/async/webdriver/installer/chrome/releases.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require "json"
 

--- a/lib/async/webdriver/installer/chrome/releases.rb
+++ b/lib/async/webdriver/installer/chrome/releases.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "json"
+
+module Async
+	module WebDriver
+		module Installer
+			module Chrome
+				# Resolves Chrome for Testing version specifiers and download URLs using the
+				# public Chrome for Testing JSON API.
+				module Releases
+					# Returns the latest known-good version for each release channel.
+					CHANNELS_URL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+					
+					# Returns every known-good version with its download URLs.
+					VERSIONS_URL = "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
+					
+					# Maps symbolic channel names to the API's title-case keys.
+					CHANNELS = {
+						stable: "Stable",
+						beta:   "Beta",
+						dev:    "Dev",
+						canary: "Canary",
+					}.freeze
+					
+					# Resolve a version specifier and platform to a version string and download URLs.
+					#
+					# @parameter version [Symbol | String] `:stable`, `:beta`, `:dev`, `:canary`,
+					#   a major version string like `"148"`, or an exact version like `"148.0.7778.56"`.
+					# @parameter platform [String] A Chrome for Testing platform string, e.g. `"mac-arm64"`.
+					# @returns [Hash] `{ version:, chrome_url:, chromedriver_url: }`
+					def self.resolve(version, platform)
+						case version
+						when Symbol    then resolve_channel(version, platform)
+						when /\A\d+\z/ then resolve_major(version, platform)
+						else                resolve_exact(version, platform)
+						end
+					end
+					
+					private
+					
+					def self.fetch_json(url)
+						require "async/http/internet"
+						
+						Sync do
+							internet = Async::HTTP::Internet.new
+							begin
+								response = internet.get(url)
+								JSON.parse(response.read)
+							ensure
+								internet.close
+							end
+						end
+					end
+					
+					def self.resolve_channel(channel, platform)
+						key = CHANNELS.fetch(channel) do
+							raise ArgumentError, "Unknown channel #{channel.inspect}. Expected one of: #{CHANNELS.keys.inspect}"
+						end
+						
+						data = fetch_json(CHANNELS_URL)
+						entry = data.dig("channels", key) or raise "Channel #{key} not found in API response"
+						
+						extract(entry, platform)
+					end
+					
+					def self.resolve_major(major, platform)
+						data = fetch_json(VERSIONS_URL)
+						
+						entry = data["versions"]
+							.select { |v| v["version"].start_with?("#{major}.") }
+							.max_by { |v| Gem::Version.new(v["version"]) }
+						
+						raise "No version found for major version #{major}" unless entry
+						
+						extract(entry, platform)
+					end
+					
+					def self.resolve_exact(version, platform)
+						data = fetch_json(VERSIONS_URL)
+						
+						entry = data["versions"].find { |v| v["version"] == version }
+						raise "Version #{version} not found" unless entry
+						
+						extract(entry, platform)
+					end
+					
+					def self.extract(entry, platform)
+						version   = entry["version"]
+						downloads = entry["downloads"]
+						
+						chrome_url = downloads["chrome"]
+							&.find { |d| d["platform"] == platform }
+							&.dig("url")
+						
+						chromedriver_url = downloads["chromedriver"]
+							&.find { |d| d["platform"] == platform }
+							&.dig("url")
+						
+						raise "No Chrome download for platform #{platform} in version #{version}" unless chrome_url
+						raise "No ChromeDriver download for platform #{platform} in version #{version}" unless chromedriver_url
+						
+						{version: version, chrome_url: chrome_url, chromedriver_url: chromedriver_url}
+					end
+				end
+			end
+		end
+	end
+end

--- a/lib/async/webdriver/installer/chrome/releases.rb
+++ b/lib/async/webdriver/installer/chrome/releases.rb
@@ -72,8 +72,8 @@ module Async
 						data = fetch_json(VERSIONS_URL)
 						
 						entry = data["versions"]
-							.select { |v| v["version"].start_with?("#{major}.") }
-							.max_by { |v| Gem::Version.new(v["version"]) }
+							.select{|v| v["version"].start_with?("#{major}.")}
+							.max_by{|v| Gem::Version.new(v["version"])}
 						
 						raise "No version found for major version #{major}" unless entry
 						
@@ -83,7 +83,7 @@ module Async
 					def self.resolve_exact(version, platform)
 						data = fetch_json(VERSIONS_URL)
 						
-						entry = data["versions"].find { |v| v["version"] == version }
+						entry = data["versions"].find{|v| v["version"] == version}
 						raise "Version #{version} not found" unless entry
 						
 						extract(entry, platform)
@@ -94,11 +94,11 @@ module Async
 						downloads = entry["downloads"]
 						
 						chrome_url = downloads["chrome"]
-							&.find { |d| d["platform"] == platform }
+							&.find{|d| d["platform"] == platform}
 							&.dig("url")
 						
 						chromedriver_url = downloads["chromedriver"]
-							&.find { |d| d["platform"] == platform }
+							&.find{|d| d["platform"] == platform}
 							&.dig("url")
 						
 						raise "No Chrome download for platform #{platform} in version #{version}" unless chrome_url

--- a/lib/async/webdriver/installer/chrome/releases.rb
+++ b/lib/async/webdriver/installer/chrome/releases.rb
@@ -34,9 +34,10 @@ module Async
 					# @returns [Hash] `{ version:, chrome_url:, chromedriver_url: }`
 					def self.resolve(version, platform)
 						case version
-						when Symbol    then resolve_channel(version, platform)
-						when /\A\d+\z/ then resolve_major(version, platform)
-						else                resolve_exact(version, platform)
+						when Symbol                    then resolve_channel(version, platform)
+						when /\A(stable|beta|dev|canary)\z/ then resolve_channel(version.to_sym, platform)
+						when /\A\d+\z/                 then resolve_major(version, platform)
+						else                                resolve_exact(version, platform)
 						end
 					end
 					

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,13 @@
 # Releases
 
+## Unreleased
+
+  - Add `Async::WebDriver::Installer::Chrome` for automatic Chrome for Testing installation and management. `Installer::Chrome.install(version)` resolves the version via the Chrome for Testing JSON API, caches binaries in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`), and returns an `Installation` with paths to both the Chrome and ChromeDriver binaries. The namespace is designed to accommodate additional browsers (e.g. `Installer::Firefox`) in the future.
+  - Add `Bridge::Chrome.for(version)` as a convenience shorthand: installs the requested version if needed, then returns a fully configured `Chrome` bridge. Versions can be a channel symbol (`:stable`, `:beta`, `:dev`, `:canary`), a major version string (`"148"`), or an exact version string (`"148.0.7778.56"`).
+  - Add `Bridge::Chrome.install(version)` for pre-downloading in CI setup steps or bake tasks, before entering the Async reactor.
+  - Fix `Bridge::Chrome#start`, `Bridge::Firefox#start`, and `Bridge::Safari#start` not forwarding the bridge's own options (including `:driver_path`) to the driver process.
+  - Rename `path:` to `driver_path:` on `Bridge::Chrome`, `Bridge::Firefox`, and `Bridge::Safari` for consistency. Add `browser_path:` to `Bridge::Chrome` (mapped to `goog:chromeOptions.binary`) in place of the former `binary:` option, consistent with `Installer::Chrome::Installation#browser_path` and `#driver_path`.
+
 ## v0.11.0
 
   - Add `Scope::Window` with `#window_rect`, `#resize_window`, `#set_window_rect`, `#maximize_window`, `#minimize_window`, and `#fullscreen_window`.

--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - Add `Async::WebDriver::Installer::Chrome` for automatic Chrome for Testing installation and management. `Installer::Chrome.install(version)` resolves the version via the Chrome for Testing JSON API, caches binaries in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`), and returns an `Installation` with paths to both the Chrome and ChromeDriver binaries. The namespace is designed to accommodate additional browsers (e.g. `Installer::Firefox`) in the future.
+  - Add `Async::WebDriver::Installer::Chrome` for automatic Chrome for Testing installation and management. `Installer::Chrome.install(version)` resolves the version via the Chrome for Testing JSON API, caches binaries in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`), and returns an `Installation` with paths to both the Chrome and ChromeDriver binaries.
   - Add `Bridge::Chrome.for(version)` as a convenience shorthand: installs the requested version if needed, then returns a fully configured `Chrome` bridge. Versions can be a channel symbol (`:stable`, `:beta`, `:dev`, `:canary`), a major version string (`"148"`), or an exact version string (`"148.0.7778.56"`).
   - Add `Bridge::Chrome.install(version)` for pre-downloading in CI setup steps or bake tasks, before entering the Async reactor.
   - Add `bake async:webdriver:chrome:install` task for installing Chrome for Testing from the command line, e.g. in CI setup steps.

--- a/releases.md
+++ b/releases.md
@@ -4,7 +4,6 @@
 
   - Add `Async::WebDriver::Installer::Chrome` for automatic Chrome for Testing installation and management. `Installer::Chrome.install(version)` resolves the version via the Chrome for Testing JSON API, caches binaries in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`), and returns an `Installation` with paths to both the Chrome and ChromeDriver binaries.
   - Add `Bridge::Chrome.for(version)` as a convenience shorthand: installs the requested version if needed, then returns a fully configured `Chrome` bridge. Versions can be a channel symbol (`:stable`, `:beta`, `:dev`, `:canary`), a major version string (`"148"`), or an exact version string (`"148.0.7778.56"`).
-  - Add `Bridge::Chrome.install(version)` for pre-downloading in CI setup steps or bake tasks, before entering the Async reactor.
   - Add `bake async:webdriver:chrome:install` task for installing Chrome for Testing from the command line, e.g. in CI setup steps.
   - Fix `Bridge::Chrome#start`, `Bridge::Firefox#start`, and `Bridge::Safari#start` not forwarding the bridge's own options (including `:driver_path`) to the driver process.
   - Rename `path:` to `driver_path:` on `Bridge::Chrome`, `Bridge::Firefox`, and `Bridge::Safari` for consistency. Add `browser_path:` to `Bridge::Chrome` (mapped to `goog:chromeOptions.binary`) in place of the former `binary:` option, consistent with `Installer::Chrome::Installation#browser_path` and `#driver_path`.

--- a/releases.md
+++ b/releases.md
@@ -5,6 +5,7 @@
   - Add `Async::WebDriver::Installer::Chrome` for automatic Chrome for Testing installation and management. `Installer::Chrome.install(version)` resolves the version via the Chrome for Testing JSON API, caches binaries in `~/.local/state/async-webdriver/` (XDG `$XDG_STATE_HOME`), and returns an `Installation` with paths to both the Chrome and ChromeDriver binaries. The namespace is designed to accommodate additional browsers (e.g. `Installer::Firefox`) in the future.
   - Add `Bridge::Chrome.for(version)` as a convenience shorthand: installs the requested version if needed, then returns a fully configured `Chrome` bridge. Versions can be a channel symbol (`:stable`, `:beta`, `:dev`, `:canary`), a major version string (`"148"`), or an exact version string (`"148.0.7778.56"`).
   - Add `Bridge::Chrome.install(version)` for pre-downloading in CI setup steps or bake tasks, before entering the Async reactor.
+  - Add `bake async:webdriver:chrome:install` task for installing Chrome for Testing from the command line, e.g. in CI setup steps.
   - Fix `Bridge::Chrome#start`, `Bridge::Firefox#start`, and `Bridge::Safari#start` not forwarding the bridge's own options (including `:driver_path`) to the driver process.
   - Rename `path:` to `driver_path:` on `Bridge::Chrome`, `Bridge::Firefox`, and `Bridge::Safari` for consistency. Add `browser_path:` to `Bridge::Chrome` (mapped to `goog:chromeOptions.binary`) in place of the former `binary:` option, consistent with `Installer::Chrome::Installation#browser_path` and `#driver_path`.
 

--- a/test/async/webdriver/bridge.rb
+++ b/test/async/webdriver/bridge.rb
@@ -32,9 +32,8 @@ Async::WebDriver::Bridge.each do |klass|
 			@driver ||= bridge.start
 		end
 		
-		def after(error = nil)
+		after do
 			@driver&.close
-			super
 		end
 		
 		it_behaves_like ABridge

--- a/test/async/webdriver/bridge.rb
+++ b/test/async/webdriver/bridge.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 
 require "sus/fixtures/async/reactor_context"
 

--- a/test/async/webdriver/installer/chrome/installation.rb
+++ b/test/async/webdriver/installer/chrome/installation.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "async/webdriver/installer/chrome/installation"
+require "tmpdir"
+
+describe Async::WebDriver::Installer::Chrome::Installation do
+	let(:platform) { Async::WebDriver::Installer::Chrome::Platform.current }
+	let(:state) { Dir.mktmpdir("async-webdriver-test-") }
+	
+	def after(error = nil)
+		FileUtils.rm_rf(state)
+		super
+	end
+	
+	with ".find" do
+		it "returns nil when nothing is installed" do
+			expect(subject.find(:stable, platform, state: state)).to be_nil
+		end
+		
+		it "returns nil for an exact version that is not installed" do
+			expect(subject.find("999.0.0.0", platform, state: state)).to be_nil
+		end
+	end
+	
+	with ".install" do
+		it "installs stable and returns an Installation" do
+			installation = subject.install(:stable, state: state)
+			
+			expect(installation).to be_a(subject)
+			expect(installation.version).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
+			expect(installation.platform).to be == platform
+			expect(File.exist?(installation.browser_path)).to be == true
+			expect(File.exist?(installation.driver_path)).to be == true
+		end
+		
+		it "creates a channel symlink" do
+			subject.install(:stable, state: state)
+			expect(File.symlink?(File.join(state, platform, "stable"))).to be == true
+		end
+		
+		it "is idempotent — second call returns without re-downloading" do
+			first  = subject.install(:stable, state: state)
+			second = subject.install(:stable, state: state)
+			expect(second.version).to be == first.version
+		end
+	end
+	
+	with ".find after .install" do
+		it "resolves the channel symlink without a network request" do
+			subject.install(:stable, state: state)
+			installation = subject.find(:stable, platform, state: state)
+			
+			expect(installation).to be_a(subject)
+			expect(File.exist?(installation.browser_path)).to be == true
+		end
+	end
+end

--- a/test/async/webdriver/installer/chrome/installation.rb
+++ b/test/async/webdriver/installer/chrome/installation.rb
@@ -29,7 +29,7 @@ describe Async::WebDriver::Installer::Chrome::Installation do
 			installation = subject.install(:stable, cache_path: cache_path)
 			
 			expect(installation).to be_a(subject)
-			expect(installation.version).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
+			expect(installation.version).to be =~ /\A\d+\.\d+\.\d+\.\d+\z/
 			expect(installation.platform).to be == platform
 			expect(File.exist?(installation.browser_path)).to be == true
 			expect(File.exist?(installation.driver_path)).to be == true

--- a/test/async/webdriver/installer/chrome/installation.rb
+++ b/test/async/webdriver/installer/chrome/installation.rb
@@ -8,26 +8,25 @@ require "tmpdir"
 
 describe Async::WebDriver::Installer::Chrome::Installation do
 	let(:platform) {Async::WebDriver::Installer::Chrome::Platform.current}
-	let(:state) {Dir.mktmpdir("async-webdriver-test-")}
+	let(:cache_path) {Dir.mktmpdir("async-webdriver-test-")}
 	
-	def after(error = nil)
-		FileUtils.rm_rf(state)
-		super
+	after do
+		FileUtils.rm_rf(cache_path)
 	end
 	
 	with ".find" do
 		it "returns nil when nothing is installed" do
-			expect(subject.find(:stable, platform, state: state)).to be_nil
+			expect(subject.find(:stable, platform, cache_path: cache_path)).to be_nil
 		end
 		
 		it "returns nil for an exact version that is not installed" do
-			expect(subject.find("999.0.0.0", platform, state: state)).to be_nil
+			expect(subject.find("999.0.0.0", platform, cache_path: cache_path)).to be_nil
 		end
 	end
 	
 	with ".install" do
 		it "installs stable and returns an Installation" do
-			installation = subject.install(:stable, state: state)
+			installation = subject.install(:stable, cache_path: cache_path)
 			
 			expect(installation).to be_a(subject)
 			expect(installation.version).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
@@ -37,21 +36,21 @@ describe Async::WebDriver::Installer::Chrome::Installation do
 		end
 		
 		it "creates a channel symlink" do
-			subject.install(:stable, state: state)
-			expect(File.symlink?(File.join(state, platform, "stable"))).to be == true
+			subject.install(:stable, cache_path: cache_path)
+			expect(File.symlink?(File.join(cache_path, platform, "stable"))).to be == true
 		end
 		
 		it "is idempotent — second call returns without re-downloading" do
-			first  = subject.install(:stable, state: state)
-			second = subject.install(:stable, state: state)
+			first  = subject.install(:stable, cache_path: cache_path)
+			second = subject.install(:stable, cache_path: cache_path)
 			expect(second.version).to be == first.version
 		end
 	end
 	
 	with ".find after .install" do
 		it "resolves the channel symlink without a network request" do
-			subject.install(:stable, state: state)
-			installation = subject.find(:stable, platform, state: state)
+			subject.install(:stable, cache_path: cache_path)
+			installation = subject.find(:stable, platform, cache_path: cache_path)
 			
 			expect(installation).to be_a(subject)
 			expect(File.exist?(installation.browser_path)).to be == true

--- a/test/async/webdriver/installer/chrome/installation.rb
+++ b/test/async/webdriver/installer/chrome/installation.rb
@@ -7,8 +7,8 @@ require "async/webdriver/installer/chrome/installation"
 require "tmpdir"
 
 describe Async::WebDriver::Installer::Chrome::Installation do
-	let(:platform) { Async::WebDriver::Installer::Chrome::Platform.current }
-	let(:state) { Dir.mktmpdir("async-webdriver-test-") }
+	let(:platform) {Async::WebDriver::Installer::Chrome::Platform.current}
+	let(:state) {Dir.mktmpdir("async-webdriver-test-")}
 	
 	def after(error = nil)
 		FileUtils.rm_rf(state)

--- a/test/async/webdriver/installer/chrome/installation.rb
+++ b/test/async/webdriver/installer/chrome/installation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require "async/webdriver/installer/chrome/installation"
 require "tmpdir"

--- a/test/async/webdriver/installer/chrome/platform.rb
+++ b/test/async/webdriver/installer/chrome/platform.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require "async/webdriver/installer/chrome/platform"
 

--- a/test/async/webdriver/installer/chrome/platform.rb
+++ b/test/async/webdriver/installer/chrome/platform.rb
@@ -21,7 +21,7 @@ describe Async::WebDriver::Installer::Chrome::Platform do
 		end
 		
 		it "raises for an unknown platform" do
-			expect { subject.chrome_binary("bogus") }.to raise_exception(RuntimeError)
+			expect{subject.chrome_binary("bogus")}.to raise_exception(RuntimeError)
 		end
 	end
 	
@@ -31,7 +31,7 @@ describe Async::WebDriver::Installer::Chrome::Platform do
 		end
 		
 		it "raises for an unknown platform" do
-			expect { subject.chromedriver_binary("bogus") }.to raise_exception(RuntimeError)
+			expect{subject.chromedriver_binary("bogus")}.to raise_exception(RuntimeError)
 		end
 	end
 end

--- a/test/async/webdriver/installer/chrome/platform.rb
+++ b/test/async/webdriver/installer/chrome/platform.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "async/webdriver/installer/chrome/platform"
+
+describe Async::WebDriver::Installer::Chrome::Platform do
+	with ".current" do
+		it "detects the current platform" do
+			platform = subject.current
+			expect(platform).to be_a(String)
+			known_platforms = ["mac-arm64", "mac-x64", "linux64", "linux-arm64", "win64", "win32"]
+			expect(known_platforms).to be(:include?, platform)
+		end
+	end
+	
+	with ".chrome_binary" do
+		it "returns a path for the current platform" do
+			expect(subject.chrome_binary(subject.current)).to be_a(String)
+		end
+		
+		it "raises for an unknown platform" do
+			expect { subject.chrome_binary("bogus") }.to raise_exception(RuntimeError)
+		end
+	end
+	
+	with ".chromedriver_binary" do
+		it "returns a path for the current platform" do
+			expect(subject.chromedriver_binary(subject.current)).to be_a(String)
+		end
+		
+		it "raises for an unknown platform" do
+			expect { subject.chromedriver_binary("bogus") }.to raise_exception(RuntimeError)
+		end
+	end
+end

--- a/test/async/webdriver/installer/chrome/releases.rb
+++ b/test/async/webdriver/installer/chrome/releases.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2025, by Samuel Williams.
+
+require "async/webdriver/installer/chrome/releases"
+require "async/webdriver/installer/chrome/platform"
+
+describe Async::WebDriver::Installer::Chrome::Releases do
+	let(:platform) { Async::WebDriver::Installer::Chrome::Platform.current }
+	
+	with ".resolve" do
+		it "resolves :stable to a version hash" do
+			result = subject.resolve(:stable, platform)
+			expect(result).to have_keys(:version, :chrome_url, :chromedriver_url)
+			expect(result[:version]).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
+		end
+		
+		it "resolves 'stable' string the same as :stable" do
+			expect(subject.resolve("stable", platform)).to be == subject.resolve(:stable, platform)
+		end
+		
+		it "resolves a major version string" do
+			major = subject.resolve(:stable, platform)[:version].split(".").first
+			result = subject.resolve(major, platform)
+			expect(result[:version]).to start_with("#{major}.")
+		end
+		
+		it "raises for an unknown channel" do
+			expect { subject.resolve(:nightly, platform) }.to raise_exception(ArgumentError)
+		end
+	end
+end

--- a/test/async/webdriver/installer/chrome/releases.rb
+++ b/test/async/webdriver/installer/chrome/releases.rb
@@ -7,7 +7,7 @@ require "async/webdriver/installer/chrome/releases"
 require "async/webdriver/installer/chrome/platform"
 
 describe Async::WebDriver::Installer::Chrome::Releases do
-	let(:platform) { Async::WebDriver::Installer::Chrome::Platform.current }
+	let(:platform) {Async::WebDriver::Installer::Chrome::Platform.current}
 	
 	with ".resolve" do
 		it "resolves :stable to a version hash" do
@@ -27,7 +27,7 @@ describe Async::WebDriver::Installer::Chrome::Releases do
 		end
 		
 		it "raises for an unknown channel" do
-			expect { subject.resolve(:nightly, platform) }.to raise_exception(ArgumentError)
+			expect{subject.resolve(:nightly, platform)}.to raise_exception(ArgumentError)
 		end
 	end
 end

--- a/test/async/webdriver/installer/chrome/releases.rb
+++ b/test/async/webdriver/installer/chrome/releases.rb
@@ -13,7 +13,7 @@ describe Async::WebDriver::Installer::Chrome::Releases do
 		it "resolves :stable to a version hash" do
 			result = subject.resolve(:stable, platform)
 			expect(result).to have_keys(:version, :chrome_url, :chromedriver_url)
-			expect(result[:version]).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
+			expect(result[:version]).to be =~ /\A\d+\.\d+\.\d+\.\d+\z/
 		end
 		
 		it "resolves 'stable' string the same as :stable" do
@@ -23,7 +23,7 @@ describe Async::WebDriver::Installer::Chrome::Releases do
 		it "resolves a major version string" do
 			major = subject.resolve(:stable, platform)[:version].split(".").first
 			result = subject.resolve(major, platform)
-			expect(result[:version]).to start_with("#{major}.")
+			expect(result[:version]).to be(:start_with?, "#{major}.")
 		end
 		
 		it "raises for an unknown channel" do

--- a/test/async/webdriver/installer/chrome/releases.rb
+++ b/test/async/webdriver/installer/chrome/releases.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2025, by Samuel Williams.
+# Copyright, 2026, by Samuel Williams.
 
 require "async/webdriver/installer/chrome/releases"
 require "async/webdriver/installer/chrome/platform"


### PR DESCRIPTION
## Summary

Adds automatic browser installation and management for Chrome for Testing, eliminating the need to manually download Chrome or chromedriver before running tests.

## New API

```ruby
# Convenience shorthand — installs if needed, returns a configured bridge:
bridge = Async::WebDriver::Bridge::Chrome.for(:stable)

# Explicit install (useful in CI setup / bake tasks before the reactor starts):
installation = Async::WebDriver::Bridge::Chrome.install(:stable)
# => #<Async::WebDriver::Installer::Chrome::Installation ...>
installation.chrome_path       # => ~/.local/state/async-webdriver/mac-arm64/148.x/chrome/...
installation.chromedriver_path # => ~/.local/state/async-webdriver/mac-arm64/148.x/chromedriver/...

# Or call the installer directly:
installation = Async::WebDriver::Installer::Chrome.install(:stable)
```

### Version specifiers

| Specifier | Meaning |
|-----------|---------|
| `:stable`, `:beta`, `:dev`, `:canary` | Named release channel |
| `"148"` | Latest patch for major version 148 |
| `"148.0.7778.56"` | Exact version |

## Structure

```
lib/async/webdriver/
  installer.rb                    # top-level namespace, documents future browsers
  installer/
    chrome.rb                     # Installer::Chrome — .install, .find, DEFAULT_STATE
    chrome/
      platform.rb                 # RUBY_PLATFORM → platform string + binary paths
      releases.rb                 # Chrome for Testing JSON API queries
      installation.rb             # on-disk state, download + extract
```

The `Installer::` namespace is designed to accommodate `Installer::Firefox` and others in the future without structural changes.

## Bug fix

`Bridge::Chrome#start` was not forwarding `@options` (including `:path`) to the `Driver`, so setting a custom chromedriver path on the bridge had no effect on the actual process. Fixed by merging `@options` in `start`.

## Installation details

- Binaries are cached in `~/.local/state/async-webdriver/{platform}/{version}/` (XDG `$XDG_STATE_HOME`-compliant)
- Downloads use `async-http` (already a dependency)
- Extraction via `unzip` / `tar` (standard on macOS and Linux)
- macOS quarantine attributes (`com.apple.quarantine`) are removed automatically after extraction